### PR TITLE
Input raw video folder directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This package synchronizes a set of videos of the same event by cross-correlating
 
 # Install and Run
 
-Skelly_synchronize can be installed through pip by running `pip install skelly_synchronize` in your terminal. Once it has installed, it can be run with the command `python -m skelly_synchronize`.
+Skelly_synchronize can be installed through pip by running `pip install skelly_synchronize` in your terminal. Once it has installed, it can be run with the command `python -m skelly_synchronize`. While running, the GUI window may appear frozen, but the terminal should show the progress. Large videos may take a significant amount of time. 
 
 # Video Requirements
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Skelly_synchronize can be installed through pip by running `pip install skelly_s
 The following requirements must be met for the script to function:
 
 1. Videos must have audio
-2. Videos must be in the same file format
+2. Videos must be in the same file format (default is ".mp4")
 3. Videos must have overlapping audio from the same real world event
 4. Videos must be in a folder titled "RawVideos", with no other videos in the folder
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This package synchronizes a set of videos of the same event by cross-correlating
 
 Skelly_synchronize can be installed through pip by running `pip install skelly_synchronize` in your terminal. Once it has installed, it can be run with the command `python -m skelly_synchronize`. While running, the GUI window may appear frozen, but the terminal should show the progress. Large videos may take a significant amount of time. 
 
+<img width="593" alt="Skelly_synchronize_gui_window" src="https://user-images.githubusercontent.com/24758117/221995127-340899d7-4f04-4f87-a2d7-ba1d49cd00e2.png">
+
 # Video Requirements
 
 The following requirements must be met for the script to function:
@@ -21,11 +23,11 @@ First clone this repository and pip install the `requirements.txt` file.
 
 Synchronize your videos by setting the path to your folder of raw videos and the file types of your videos into `skelly_synchronize.py`, lines 343-344, then run the file. 
 
-![Main](https://user-images.githubusercontent.com/24758117/220470598-580360ef-8d4f-447c-820e-cc4d2d544c07.png)
+<img width="559" alt="skelly_synchronize_main_function" src="https://user-images.githubusercontent.com/24758117/221996311-07dab11f-0104-4407-b921-40cd364b39bc.png">
 
 The terminal output while running should look like this:
 
-<img width="1250" alt="TerminalOutput" src="https://user-images.githubusercontent.com/24758117/220470626-c3592b65-6d8f-439b-87e7-20b83d6aff0f.png">
+<img width="1250" alt="TerminalOutput" src="https://user-images.githubusercontent.com/24758117/221996277-a925c457-205c-411d-aaaa-eda7ca774fed.png">
 
 A `SyncedVideos` folder will be created in the session folder and filled with the synchronized video files. The session folder will also have an `AudioFiles` folder containing audio files of the raw videos, which are used in processing.
 

--- a/README.md
+++ b/README.md
@@ -12,28 +12,14 @@ The following requirements must be met for the script to function:
 
 1. Videos must have audio
 2. Videos must be in the same file format (default is ".mp4")
-3. Videos must have overlapping audio from the same real world event
-4. Videos must be in a folder titled "RawVideos", with no other videos in the folder
+3. All videos in folder must have overlapping audio from the same real world event
 
-# Expected File Structure
-
-To function correctly, Skelly Synchronize expects the following folder structure:
-```
-freemocap_data_folder:
-    sessionID:
-        RawVideos:
-            Cam0.mp4
-            Cam1.mp4
-            ...
-    ...
-```
-The camera names can be changed, and the file format may changed as well, although freemocap currently only uses `.mp4`.
 
 # How to run from source
 
-first clone this repository and pip install the `requirements.txt` file.
+First clone this repository and pip install the `requirements.txt` file.
 
-Synchronize your videos by setting the path to your freemocap data folder, your sessionID, and the file types of your videos into `skelly_synchronize.py`, then run the file. The sessionID should be the name of a subfolder of your freemocap data folder, and should contain a subfolder called `RawVideos` containing the videos that need synching.
+Synchronize your videos by setting the path to your folder of raw videos and the file types of your videos into `skelly_synchronize.py`, lines 343-344, then run the file. 
 
 ![Main](https://user-images.githubusercontent.com/24758117/220470598-580360ef-8d4f-447c-820e-cc4d2d544c07.png)
 

--- a/skelly_synchronize/gui/skelly_synchronize_gui.py
+++ b/skelly_synchronize/gui/skelly_synchronize_gui.py
@@ -18,18 +18,20 @@ class MainWindow(QMainWindow):
         super().__init__()
         self._folder_path = None
 
-        self.setGeometry(100, 100, 600, 600)
+        self.setGeometry(100, 100, 600, 300)
 
         widget = QWidget()
         self._layout = QVBoxLayout()
         widget.setLayout(self._layout)
         self.setCentralWidget(widget)
 
-        self.folder_open_button = QPushButton("Load a folder")
+        self.folder_open_button = QPushButton("Load folder of raw videos")
         self._layout.addWidget(self.folder_open_button)
         self.folder_open_button.clicked.connect(self._open_session_folder_dialog)
 
-        self.folder_path_label = QLabel(f"Your chosen folder is: {self._folder_path}")
+        self.folder_path_label = QLabel(
+            f"Selected folder of raw videos: {self._folder_path}"
+        )
         self.folder_path_label.setFixedHeight(15)
         self._layout.addWidget(self.folder_path_label)
 
@@ -43,7 +45,9 @@ class MainWindow(QMainWindow):
     def _open_session_folder_dialog(self):
         folder_input = QFileDialog.getExistingDirectory(None, "Choose a folder")
         self._folder_path = Path(folder_input)
-        self.folder_path_label.setText(f"Your chosen folder is: {self._folder_path}")
+        self.folder_path_label.setText(
+            f"Selected folder of raw videos: {self._folder_path}"
+        )
         self.run_button.run_button_widget.setEnabled(True)
 
 

--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -321,13 +321,11 @@ class VideoSynchronize:
         return normalized_lag_dictionary
 
 
-def synchronize_videos(session_folder_path: Path, file_type=".mp4"):
+def synchronize_videos(raw_video_folder_path: Path, file_type=".mp4"):
     # start timer to measure performance
     start_timer = time.time()
 
-    raw_video_folder_name = "RawVideos"
-    raw_video_folder_path = session_folder_path / raw_video_folder_name
-
+    session_folder_path = raw_video_folder_path.parent.absolute()
     video_file_list = get_video_file_list(raw_video_folder_path, ".mp4")
 
     synchronize = VideoSynchronize()
@@ -342,8 +340,6 @@ def synchronize_videos(session_folder_path: Path, file_type=".mp4"):
 
 
 if __name__ == "__main__":
-    sessionID = "sessionID"
-    freemocap_data_path = Path("data/path/here")
-    session_folder_path = freemocap_data_path / sessionID
+    raw_video_folder_path = Path("path/to/your/folder/of/raw/videos")
     file_type = "MP4"
-    synchronize_videos(session_folder_path, file_type)
+    synchronize_videos(raw_video_folder_path, file_type)


### PR DESCRIPTION
Fixes #4 by allowing direct input of the folder containing raw videos, and puts the synced videos folder in the parent directory of the raw video folder.