### PR TITLE
Switch video trimming method to deffcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This package synchronizes a set of videos of the same event by cross-correlating
 
 Skelly_synchronize can be installed through pip by running `pip install skelly_synchronize` in your terminal. Once it has installed, it can be run with the command `python -m skelly_synchronize`. While running, the GUI window may appear frozen, but the terminal should show the progress. Large videos may take a significant amount of time. 
 
+Skelly_synchronize currently depends on FFmpeg, a command line tool that handles the video files. If you do not have FFmpeg downloaded, you will need to install it separately. You can download FFmpeg here: https://ffmpeg.org/download.html
+
 <img width="593" alt="Skelly_synchronize_gui_window" src="https://user-images.githubusercontent.com/24758117/221995127-340899d7-4f04-4f87-a2d7-ba1d49cd00e2.png">
 
 # Video Requirements
@@ -14,6 +16,7 @@ The following requirements must be met for the script to function:
 
 1. Videos must have audio
 2. Videos must be in the same file format (default is ".mp4")
+3. Videos must have the exact same framerate (frames per second). There are often slight differences between brands/models of camera that lead to one camera's "60 fps" being different from another's. If your frame rates do not match, an error will be thrown.
 3. All videos in folder must have overlapping audio from the same real world event
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
 "numpy",
 "scipy",
 "setuptools",
+"opencv-python",
+"deffcode",
 ] #add additional dependencies here - try to pin versions as minimally as possible
 
 requires-python = ">=3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
+deffcode==0.2.5
 librosa==0.10.0
 numpy==1.21.5
-PyQt6==6.4.2
+opencv_python==4.7.0.72
+PyQt6==6.5.0
 pytest==7.1.2
-scipy==1.10.0
-setuptools==65.6.3
+scipy==1.10.1

--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -4,14 +4,15 @@ import logging
 import subprocess
 import cv2
 import numpy as np
+import json
 from scipy import signal
 from pathlib import Path
 from typing import Dict
+from deffcode import FFdecoder
 
 logging.basicConfig(level=logging.INFO)
 
 from utils.get_video_files import get_video_file_list
-
 
 class VideoSynchronize:
     """Class of functions for time synchronizing and trimming video files based on cross correlation of their audio."""
@@ -24,10 +25,10 @@ class VideoSynchronize:
         self,
         session_folder_path: Path,
         video_file_list: list,
-        video_handler: str = "opencv",
+        video_handler: str = "deffcode",
     ) -> list:
         """Run the functions from the VideoSynchronize class to synchronize all videos with the given file type in the base path folder.
-        Uses opencv to handle the video files as default, set "video_handler" to "ffmpeg" to use ffmpeg methods instead.
+        Uses deffcode and opencv to handle the video files as default, set "video_handler" to "ffmpeg" to use ffmpeg methods instead.
         ffmpeg is used to get audio from the video files with either method.
         """
 
@@ -43,30 +44,40 @@ class VideoSynchronize:
         self.audio_folder_path.mkdir(parents=False, exist_ok=True)
 
         # create dictionaries with video and audio information
-        video_info_dict = self._get_video_info_dict(video_file_list, "ffmpeg")
+        video_info_dict = self._get_video_info_dict(
+            video_filepath_list=video_file_list, video_handler="ffmpeg"
+        )
         audio_signal_dict = self._get_audio_files(
-            video_info_dict, audio_extension="wav"
+            video_info_dict=video_info_dict, audio_extension="wav"
         )
 
         # get video fps and audio sample rate
-        fps_list = self._get_fps_list(video_info_dict)
-        audio_sample_rates = self._get_audio_sample_rates(audio_signal_dict)
+        fps_list = self._get_fps_list(video_info_dict=video_info_dict)
+        audio_sample_rates = self._get_audio_sample_rates(
+            audio_signal_dict=audio_signal_dict
+        )
 
         # frame rates and audio sample rates must be the same duration for the trimming process to work correctly
-        fps = self._check_rates(fps_list)
-        audio_sample_rate = self._check_rates(audio_sample_rates)
+        fps = self._check_rates(rate_list=fps_list)
+        audio_sample_rate = self._check_rates(rate_list=audio_sample_rates)
 
         # find the lags between starting times
-        lag_dict = self._find_lags(audio_signal_dict, audio_sample_rate)
+        lag_dict = self._find_lags(
+            audio_signal_dict=audio_signal_dict, sample_rate=audio_sample_rate
+        )
 
         synched_video_names = self._trim_videos(
-            video_info_dict, lag_dict, fps, video_handler
+            video_info_dict=video_info_dict,
+            lag_dict=lag_dict,
+            fps=fps,
+            video_handler=video_handler,
         )
         return synched_video_names
 
     def _get_video_info_dict(
-        self, video_filepath_list: list, video_handler: str = "opencv"
+        self, video_filepath_list: list, video_handler: str = "ffmpeg"
     ) -> Dict[str, dict]:
+        """Get a dictionary with video information from the given video file paths."""
         video_info_dict = dict()
         for video_filepath in video_filepath_list:
             video_dict = dict()
@@ -77,28 +88,29 @@ class VideoSynchronize:
 
             if video_handler == "ffmpeg":
                 video_dict["video duration"] = self._extract_video_duration_ffmpeg(
-                    str(video_filepath)
+                    file_pathstring=str(video_filepath)
                 )
                 video_dict["video fps"] = self._extract_video_fps_ffmpeg(
-                    str(video_filepath)
+                    file_pathstring=str(video_filepath)
                 )
                 video_info_dict[video_name] = video_dict
-            if video_handler == "opencv":
-                # open capture function
-                video_dict["video duration"] = self._extract_video_duration_opencv(
-                    str(video_filepath)
-                )
-                video_dict["video fps"] = self._extract_video_fps_opencv(
-                    str(video_filepath)
-                )
-                # close capture function
-                video_info_dict[video_name] = video_dict
+            # if video_handler == "opencv":
+            #     # open capture function
+            #     video_dict["video duration"] = self._extract_video_duration_opencv(
+            #         str(video_filepath)
+            #     )
+            #     video_dict["video fps"] = self._extract_video_fps_opencv(
+            #         str(video_filepath)
+            #     )
+            #     # close capture function
+            #     video_info_dict[video_name] = video_dict
 
         return video_info_dict
 
     def _get_audio_files(
         self, video_info_dict: Dict[str, dict], audio_extension: str
     ) -> dict:
+        """Get a dictionary with audio files and information from the given video file paths."""
         audio_signal_dict = dict()
         for video_dict in video_info_dict.values():
             self._extract_audio_from_video_ffmpeg(
@@ -111,7 +123,7 @@ class VideoSynchronize:
             audio_name = video_dict["camera name"] + "." + audio_extension
 
             audio_signal, audio_rate = librosa.load(
-                self.audio_folder_path / audio_name, sr=None
+                path=self.audio_folder_path / audio_name, sr=None
             )
 
             audio_duration = librosa.get_duration(y=audio_signal, sr=audio_rate)
@@ -126,6 +138,7 @@ class VideoSynchronize:
         return audio_signal_dict
 
     def _get_fps_list(self, video_info_dict: Dict[str, dict]):
+        """Get list of the frames per second in earch video"""
         return [video_dict["video fps"] for video_dict in video_info_dict.values()]
 
     def _check_rates(self, rate_list: list):
@@ -150,14 +163,14 @@ class VideoSynchronize:
 
         lag_dict = {
             single_audio_dict["camera name"]: self._cross_correlate(
-                audio_signal_dict[comparison_file_key]["audio file"],
-                single_audio_dict["audio file"],
+                audio1=audio_signal_dict[comparison_file_key]["audio file"],
+                audio2=single_audio_dict["audio file"],
             )
             / sample_rate
             for single_audio_dict in audio_signal_dict.values()
         }  # cross correlates all audio to the first audio file in the dict, and divides by the audio sample rate in order to get the lag in seconds
 
-        normalized_lag_dict = self._normalize_lag_dictionary(lag_dict)
+        normalized_lag_dict = self._normalize_lag_dictionary(lag_dictionary=lag_dict)
 
         logging.info(
             f"original lag dict: {lag_dict} normalized lag dict: {normalized_lag_dict}"
@@ -170,49 +183,49 @@ class VideoSynchronize:
         video_info_dict: Dict[str, dict],
         lag_dict: Dict[str, float],
         fps: float,
-        video_handler: str = "opencv",
+        video_handler: str = "deffcode",
     ) -> list:
         """Take a list of video files and a list of lags, and make all videos start and end at the same time."""
 
-        minimum_duration = self._find_minimum_video_duration(video_info_dict, lag_dict)
+        minimum_duration = self._find_minimum_video_duration(video_info_dict=video_info_dict, lag_dict=lag_dict)
         minimum_frames = int(minimum_duration * fps)
         trimmed_video_filenames = []  # can be used for plotting
 
         for video_dict in video_info_dict.values():
             logging.debug(f"trimming video file {video_dict['camera name']}")
-            if video_dict["camera name"].split("_")[0] == "raw":
-                synced_video_name = "synced_" + video_dict["camera name"][4:] + ".mp4"
-            else:
-                synced_video_name = "synced_" + video_dict["camera name"] + ".mp4"
+            synced_video_name = self._name_synced_video(raw_video_filename=video_dict["camera name"])
             trimmed_video_filenames.append(
                 synced_video_name
             )  # add new name to list to reference for plotting
 
             start_time = lag_dict[video_dict["camera name"]]
             start_frame = int(start_time * fps)
+            frame_list = self._get_frame_list(
+                start_frame=start_frame, duration_frames=minimum_frames
+            )
 
             if video_handler == "ffmpeg":
                 logging.info(f"Saving video - Cam name: {video_dict['camera name']}")
                 logging.info(f"desired saving duration is: {minimum_duration} seconds")
-                if video_handler == "ffmpeg":
-                    self._trim_single_video_ffmpeg(
-                        input_video_pathstring=video_dict["video pathstring"],
-                        start_time=start_time,
-                        desired_duration=minimum_duration,
-                        output_video_pathstring=str(
-                            self.synchronized_folder_path / synced_video_name
-                        ),
-                    )
+                self._trim_single_video_ffmpeg(
+                    input_video_pathstring=video_dict["video pathstring"],
+                    start_time=start_time,
+                    desired_duration=minimum_duration,
+                    output_video_pathstring=str(
+                        self.synchronized_folder_path / synced_video_name
+                    ),
+                )
                 logging.info(
                     f"Video Saved - Cam name: {video_dict['camera name']}, Video Duration in Seconds: {minimum_duration}"
                 )
-            if video_handler == "opencv":
+            if video_handler == "deffcode":
                 logging.info(f"Saving video - Cam name: {video_dict['camera name']}")
-                logging.info(f"start frame is: {start_frame} desired saving duration is: {minimum_frames} frames")
-                self._trim_single_video_opencv(
+                logging.info(
+                    f"start frame is: {start_frame} desired saving duration is: {minimum_frames} frames"
+                )
+                self._trim_single_video_deffcode(
                     input_video_pathstring=video_dict["video pathstring"],
-                    start_frame=start_frame,
-                    desired_duration_frames=minimum_frames,
+                    frame_list=frame_list,
                     output_video_pathstring=str(
                         self.synchronized_folder_path / synced_video_name
                     ),
@@ -220,6 +233,8 @@ class VideoSynchronize:
                 logging.info(
                     f"Video Saved - Cam name: {video_dict['camera name']}, Video Duration in Frames: {minimum_frames}"
                 )
+
+            # TODO add test that video duration in frames is equal to minimum_duration_frames
 
         return trimmed_video_filenames
 
@@ -295,8 +310,7 @@ class VideoSynchronize:
     def _trim_single_video_opencv(
         self,
         input_video_pathstring: str,
-        start_frame: int,
-        desired_duration_frames: int,
+        frame_list: list,
         output_video_pathstring: str,
     ):
         """Trim a video from the start frame to last a desired amount of frames using opencv's VideoWriter"""
@@ -310,7 +324,9 @@ class VideoSynchronize:
         logging.info(
             f"frame width: {frame_width} frame height: {frame_height} fps: {fps}"
         )
-        logging.info(f"original video frame count: {input_video_capture.get(cv2.CAP_PROP_FRAME_COUNT)}")
+        logging.info(
+            f"original video frame count: {input_video_capture.get(cv2.CAP_PROP_FRAME_COUNT)}"
+        )
 
         fourcc = cv2.VideoWriter_fourcc(*"H264")
         logging.info(f"creating video writer object for {output_video_pathstring}")
@@ -327,23 +343,67 @@ class VideoSynchronize:
             if not success:
                 break
 
-            if (
-                current_frame >= start_frame
-                and written_frames < desired_duration_frames
-            ):
+            if current_frame in frame_list:
                 video_writer_object.write(frame)
                 written_frames += 1
 
-            if written_frames == desired_duration_frames:
+            if written_frames == len(frame_list):
                 break
 
-            logging.info(f"current frame: {current_frame} written_frames: {written_frames}")
+            logging.info(
+                f"current frame: {current_frame} written_frames: {written_frames}"
+            )
             current_frame += 1
-
 
         logging.info(f"releasing capture object for {input_video_pathstring}")
         input_video_capture.release()
         logging.info(f"releasing video writer object for {output_video_pathstring}")
+        video_writer_object.release()
+
+    def _trim_single_video_deffcode(
+        self,
+        input_video_pathstring: str,
+        frame_list: list,
+        output_video_pathstring: str,
+    ):
+        decoder = FFdecoder(
+            input_video_pathstring,
+            frame_format="bgr24",
+            verbose=True,
+        ).formulate()
+
+        metadata_dictionary = json.loads(decoder.metadata)
+
+        fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+        framerate = metadata_dictionary["output_framerate"]
+        framesize = tuple(metadata_dictionary["output_frames_resolution"])
+
+        video_writer_object = cv2.VideoWriter(
+            output_video_pathstring, fourcc, framerate, framesize
+        )
+
+        current_frame = 0
+        written_frames = 0
+
+        # grab the BGR24 frame from the decoder
+        for frame in decoder.generateFrame():
+            # check if frame is None
+            if frame is None:
+                break
+
+            if current_frame in frame_list:
+                video_writer_object.write(frame)
+                written_frames += 1
+
+            if written_frames == len(frame_list):
+                break
+
+            current_frame += 1
+
+        # terminate the decoder
+        decoder.terminate()
+
+        # safely close writer
         video_writer_object.release()
 
     def _trim_single_video_ffmpeg(
@@ -370,6 +430,10 @@ class VideoSynchronize:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )
+
+    def _get_frame_list(self, start_frame: int, duration_frames: int) -> list:
+        """Get a list of frame numbers for video to be trimmed to"""
+        return [start_frame + frame for frame in range(duration_frames)]
 
     def _get_audio_sample_rates(self, audio_signal_dict: Dict[str, float]) -> list:
         """Get the sample rates of each audio file and return them in a list"""
@@ -402,13 +466,13 @@ class VideoSynchronize:
         return lag
 
     def _find_minimum_video_duration(
-        self, video_info_dict: Dict[str, dict], lag_list: list
+        self, video_info_dict: Dict[str, dict], lag_dict: dict
     ) -> float:
         """Take a list of video files and a list of lags, and find what the shortest video is starting from each videos lag offset"""
 
         min_duration = min(
             [
-                video_dict["video duration"] - lag_list[video_dict["camera name"]]
+                video_dict["video duration"] - lag_dict[video_dict["camera name"]]
                 for video_dict in video_info_dict.values()
             ]
         )
@@ -429,16 +493,29 @@ class VideoSynchronize:
 
         return normalized_lag_dictionary
 
+    def _name_synced_video(self, raw_video_filename: str) -> str:
+        """Take a raw video filename, remove the raw prefix if its there, and return the synced video filename"""
+        if raw_video_filename.split("_")[0] == "raw":
+            synced_video_name = "synced_" + raw_video_filename[4:] + ".mp4"
+        else:
+            synced_video_name = "synced_" + raw_video_filename + ".mp4"
 
-def synchronize_videos(raw_video_folder_path: Path, file_type=".mp4"):
+        return synced_video_name
+
+
+def synchronize_videos(raw_video_folder_path: Path, file_type: str = ".mp4"):
     # start timer to measure performance
     start_timer = time.time()
 
     session_folder_path = raw_video_folder_path.parent.absolute()
-    video_file_list = get_video_file_list(raw_video_folder_path, ".mp4")
+    video_file_list = get_video_file_list(
+        folder_path=raw_video_folder_path, file_type=file_type
+    )
 
     synchronize = VideoSynchronize()
-    synchronize.synchronize(session_folder_path, video_file_list)
+    synchronize.synchronize(
+        session_folder_path=session_folder_path, video_file_list=video_file_list
+    )
 
     # end performance timer
     end_timer = time.time()
@@ -451,4 +528,4 @@ def synchronize_videos(raw_video_folder_path: Path, file_type=".mp4"):
 if __name__ == "__main__":
     raw_video_folder_path = Path("path/to/your/folder/of/raw/videos")
     file_type = "MP4"
-    synchronize_videos(raw_video_folder_path, file_type)
+    synchronize_videos(raw_video_folder_path=raw_video_folder_path, file_type=file_type)

--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -13,6 +13,7 @@ from deffcode import FFdecoder
 logging.basicConfig(level=logging.INFO)
 
 from skelly_synchronize.utils.get_video_files import get_video_file_list
+from skelly_synchronize.utils.path_handling_utilities import get_parent_directory, get_file_name
 from skelly_synchronize.tests.utilities.check_list_values_are_equal import check_list_values_are_equal
 from skelly_synchronize.tests.utilities.get_number_of_frames_of_videos_in_a_folder import get_number_of_frames_of_videos_in_a_folder
 
@@ -76,7 +77,7 @@ class VideoSynchronize:
         )
 
         synchronized_video_framecounts = get_number_of_frames_of_videos_in_a_folder(folder_path=self.synchronized_folder_path)
-        logging.info(f"All video framerates are equal to {check_list_values_are_equal(synchronized_video_framecounts)}")
+        logging.info(f"All videos are {check_list_values_are_equal(synchronized_video_framecounts)} frames long")
 
         return synched_video_names
 
@@ -89,7 +90,7 @@ class VideoSynchronize:
             video_dict = dict()
             video_dict["video filepath"] = video_filepath
             video_dict["video pathstring"] = str(video_filepath)
-            video_name = str(video_filepath).split("/")[-1]
+            video_name = get_file_name(video_filepath)
             video_dict["camera name"] = video_name.split(".")[0]
 
             if video_handler == "ffmpeg":
@@ -100,16 +101,6 @@ class VideoSynchronize:
                     file_pathstring=str(video_filepath)
                 )
                 video_info_dict[video_name] = video_dict
-            # if video_handler == "opencv":
-            #     # open capture function
-            #     video_dict["video duration"] = self._extract_video_duration_opencv(
-            #         str(video_filepath)
-            #     )
-            #     video_dict["video fps"] = self._extract_video_fps_opencv(
-            #         str(video_filepath)
-            #     )
-            #     # close capture function
-            #     video_info_dict[video_name] = video_dict
 
         return video_info_dict
 
@@ -444,14 +435,14 @@ def synchronize_videos(raw_video_folder_path: Path, file_type: str = ".mp4"):
     # start timer to measure performance
     start_timer = time.time()
 
-    session_folder_path = raw_video_folder_path.parent.absolute()
+    session_folder_path = get_parent_directory(raw_video_folder_path)
     video_file_list = get_video_file_list(
         folder_path=raw_video_folder_path, file_type=file_type
     )
 
     synchronize = VideoSynchronize()
     synchronize.synchronize(
-        session_folder_path=session_folder_path, video_file_list=video_file_list
+        session_folder_path=session_folder_path, video_file_list=video_file_list,
     )
 
     # end performance timer

--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -302,59 +302,6 @@ class VideoSynchronize:
 
         return video_fps
 
-    def _trim_single_video_opencv(
-        self,
-        input_video_pathstring: str,
-        frame_list: list,
-        output_video_pathstring: str,
-    ):
-        """Trim a video from the start frame to last a desired amount of frames using opencv's VideoWriter"""
-        logging.info(f"opening capture object for {input_video_pathstring}")
-        input_video_capture = cv2.VideoCapture(input_video_pathstring)
-
-        frame_width = int(input_video_capture.get(cv2.CAP_PROP_FRAME_WIDTH))
-        frame_height = int(input_video_capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
-        fps = int(input_video_capture.get(cv2.CAP_PROP_FPS))
-
-        logging.info(
-            f"frame width: {frame_width} frame height: {frame_height} fps: {fps}"
-        )
-        logging.info(
-            f"original video frame count: {input_video_capture.get(cv2.CAP_PROP_FRAME_COUNT)}"
-        )
-
-        fourcc = cv2.VideoWriter_fourcc(*"H264")
-        logging.info(f"creating video writer object for {output_video_pathstring}")
-        video_writer_object = cv2.VideoWriter(
-            output_video_pathstring, fourcc, fps, (frame_width, frame_height)
-        )
-
-        current_frame = 0
-        written_frames = 0
-
-        logging.info(f"writing video...")
-        while True:
-            success, frame = input_video_capture.read()
-            if not success:
-                break
-
-            if current_frame in frame_list:
-                video_writer_object.write(frame)
-                written_frames += 1
-
-            if written_frames == len(frame_list):
-                break
-
-            logging.info(
-                f"current frame: {current_frame} written_frames: {written_frames}"
-            )
-            current_frame += 1
-
-        logging.info(f"releasing capture object for {input_video_pathstring}")
-        input_video_capture.release()
-        logging.info(f"releasing video writer object for {output_video_pathstring}")
-        video_writer_object.release()
-
     def _trim_single_video_deffcode(
         self,
         input_video_pathstring: str,
@@ -380,9 +327,7 @@ class VideoSynchronize:
         current_frame = 0
         written_frames = 0
 
-        # grab the BGR24 frame from the decoder
         for frame in decoder.generateFrame():
-            # check if frame is None
             if frame is None:
                 break
 
@@ -395,10 +340,7 @@ class VideoSynchronize:
 
             current_frame += 1
 
-        # terminate the decoder
         decoder.terminate()
-
-        # safely close writer
         video_writer_object.release()
 
     def _trim_single_video_ffmpeg(

--- a/skelly_synchronize/tests/test_trim_single_video_deffcode.py
+++ b/skelly_synchronize/tests/test_trim_single_video_deffcode.py
@@ -11,29 +11,45 @@ print(f"adding base_package_path: {base_package_path} : to sys.path")
 sys.path.insert(0, str(base_package_path))  # add parent directory to sys.path
 
 from skelly_synchronize.skelly_synchronize import VideoSynchronize
-from skelly_synchronize.tests.utilities.find_frame_count_of_video import find_frame_count_of_video
+from skelly_synchronize.tests.utilities.find_frame_count_of_video import (
+    find_frame_count_of_video,
+)
+
 
 @pytest.fixture
 def test_video_pathstring():
     return "/Users/philipqueen/Documents/RawVideos/Cam0.MP4"
 
+
 @pytest.fixture
 def output_video_pathstring():
     return "/Users/philipqueen/Movies/ClippedCam0.mp4"
 
+
 @pytest.fixture
 def start_frame():
-    return 51
+    return 1
+
 
 @pytest.fixture
 def desired_duration_frames():
-    return 1000
+    return 1500
 
-def test_trim_single_video_opencv(test_video_pathstring, start_frame, desired_duration_frames, output_video_pathstring, caplog):
+
+def test_trim_single_video_deffcode(
+    test_video_pathstring,
+    start_frame,
+    desired_duration_frames,
+    output_video_pathstring,
+    caplog,
+):
     caplog.set_level(logging.INFO)
     test_synchronize = VideoSynchronize()
-    test_synchronize._trim_single_video_opencv(test_video_pathstring, start_frame, desired_duration_frames, output_video_pathstring)
+    test_synchronize._trim_single_video_deffcode(
+        input_video_pathstring=test_video_pathstring,
+        start_frame=start_frame,
+        desired_duration_frames=desired_duration_frames,
+        output_video_pathstring=output_video_pathstring,
+    )
 
     assert find_frame_count_of_video(output_video_pathstring) == desired_duration_frames
-
-    

--- a/skelly_synchronize/tests/test_trim_single_video_opencv.py
+++ b/skelly_synchronize/tests/test_trim_single_video_opencv.py
@@ -1,0 +1,39 @@
+import pytest
+import sys
+import logging
+from pathlib import Path
+
+print(f"Thank you for using skelly_synchronize!")
+print(f"This is printing from: {__file__}")
+
+base_package_path = Path(__file__).parent.parent.parent
+print(f"adding base_package_path: {base_package_path} : to sys.path")
+sys.path.insert(0, str(base_package_path))  # add parent directory to sys.path
+
+from skelly_synchronize.skelly_synchronize import VideoSynchronize
+from skelly_synchronize.tests.utilities.find_frame_count_of_video import find_frame_count_of_video
+
+@pytest.fixture
+def test_video_pathstring():
+    return "/Users/philipqueen/Documents/RawVideos/Cam0.MP4"
+
+@pytest.fixture
+def output_video_pathstring():
+    return "/Users/philipqueen/Movies/ClippedCam0.mp4"
+
+@pytest.fixture
+def start_frame():
+    return 51
+
+@pytest.fixture
+def desired_duration_frames():
+    return 1000
+
+def test_trim_single_video_opencv(test_video_pathstring, start_frame, desired_duration_frames, output_video_pathstring, caplog):
+    caplog.set_level(logging.INFO)
+    test_synchronize = VideoSynchronize()
+    test_synchronize._trim_single_video_opencv(test_video_pathstring, start_frame, desired_duration_frames, output_video_pathstring)
+
+    assert find_frame_count_of_video(output_video_pathstring) == desired_duration_frames
+
+    

--- a/skelly_synchronize/tests/utilities/check_list_values_are_equal.py
+++ b/skelly_synchronize/tests/utilities/check_list_values_are_equal.py
@@ -1,0 +1,16 @@
+import logging
+from typing import Any, List
+
+def check_list_values_are_equal(input_list: List[Any]) -> Any:
+    """Check if values in list are all equal, throw an exception if not (or if list is empty)."""
+    unique_values = set(input_list)
+
+    if len(unique_values) == 0:
+        raise Exception("list empty")
+
+    if len(unique_values) == 1:
+        unique_value = unique_values.pop()
+        logging.debug(f"all values in list are equal to {unique_value}")
+        return unique_value
+    else:
+        raise Exception(f"list values are not equal, list is {input_list}")

--- a/skelly_synchronize/tests/utilities/find_frame_count_of_video.py
+++ b/skelly_synchronize/tests/utilities/find_frame_count_of_video.py
@@ -1,8 +1,8 @@
 import cv2
 
-def find_frame_count_of_video(video_pathstring):
+def find_frame_count_of_video(video_pathstring: str):
     video_capture_object = cv2.VideoCapture(video_pathstring)
     frame_count = video_capture_object.get(cv2.CAP_PROP_FRAME_COUNT)
     video_capture_object.release()
 
-    return frame_count
+    return int(frame_count)

--- a/skelly_synchronize/tests/utilities/find_frame_count_of_video.py
+++ b/skelly_synchronize/tests/utilities/find_frame_count_of_video.py
@@ -1,0 +1,8 @@
+import cv2
+
+def find_frame_count_of_video(video_pathstring):
+    video_capture_object = cv2.VideoCapture(video_pathstring)
+    frame_count = video_capture_object.get(cv2.CAP_PROP_FRAME_COUNT)
+    video_capture_object.release()
+
+    return frame_count

--- a/skelly_synchronize/tests/utilities/get_number_of_frames_of_videos_in_a_folder.py
+++ b/skelly_synchronize/tests/utilities/get_number_of_frames_of_videos_in_a_folder.py
@@ -1,0 +1,35 @@
+import logging
+import sys
+from pathlib import Path
+from typing import Union
+
+logger = logging.getLogger(__name__)
+
+base_package_path = Path(__file__).parent.parent.parent.parent
+print(f"adding base_package_path: {base_package_path} : to sys.path")
+sys.path.insert(0, str(base_package_path))  # add parent directory to sys.path
+
+from skelly_synchronize.utils.get_video_files import get_video_file_list
+from skelly_synchronize.tests.utilities.find_frame_count_of_video import find_frame_count_of_video
+
+def get_number_of_frames_of_videos_in_a_folder(folder_path: Union[str, Path]):
+    """
+    Get the number of frames in the first video in a folder
+    """
+
+    list_of_video_paths = get_video_file_list(folder_path=Path(folder_path), file_type=".mp4")
+
+    if len(list_of_video_paths) == 0:
+        logger.error(f"No videos found in {folder_path}")
+        return None
+
+    frame_count_list = []
+    for video_path in list_of_video_paths:
+        frame_count = find_frame_count_of_video(video_pathstring=str(video_path))
+        frame_count_list.append(int(frame_count))
+
+    return frame_count_list
+
+if __name__ == "__main__":
+    folder_path = Path("/Users/philipqueen/Documents/Humon Research Lab/FreeMocap_Data/iPhoneTesting/SyncedVideos")
+    print(get_number_of_frames_of_videos_in_a_folder(folder_path))

--- a/skelly_synchronize/tests/utilities/get_number_of_frames_of_videos_in_a_folder.py
+++ b/skelly_synchronize/tests/utilities/get_number_of_frames_of_videos_in_a_folder.py
@@ -31,5 +31,5 @@ def get_number_of_frames_of_videos_in_a_folder(folder_path: Union[str, Path]):
     return frame_count_list
 
 if __name__ == "__main__":
-    folder_path = Path("/Users/philipqueen/Documents/Humon Research Lab/FreeMocap_Data/iPhoneTesting/SyncedVideos")
+    folder_path = Path("YOUR/FOLDER/PATH")
     print(get_number_of_frames_of_videos_in_a_folder(folder_path))

--- a/skelly_synchronize/utils/path_handling_utilities.py
+++ b/skelly_synchronize/utils/path_handling_utilities.py
@@ -5,6 +5,7 @@ from typing import Union
 logging.basicConfig(level=logging.INFO)
 
 def get_parent_directory(path: Union[str, Path]) -> Path:
+    """Get the parent directory of the specified path."""
     path = ensure_path_object(path)
 
     logging.info(f"Input path: {path}")
@@ -18,10 +19,22 @@ def get_parent_directory(path: Union[str, Path]) -> Path:
 
     return parent_directory
 
+def create_directory(parent_directory: Path, directory_name: str) -> Path:
+    """Create a new directory under the specified parent directory."""
+    parent_directory = ensure_path_object(parent_directory)
+    new_directory_path = parent_directory / directory_name
+
+    try:
+        new_directory_path.mkdir(parents=True, exist_ok=True)
+        logging.info(f"Created directory: {new_directory_path}")
+    except Exception as e:
+        logging.error(f"Error creating directory: {new_directory_path}. Exception: {e}")
+        raise
+
+    return new_directory_path
+
 def get_file_name(file_path: Union[str, Path]) -> str:
-    """
-    Get the name of the file without directories or file extensions.
-    """
+    """Get the name of the file without directories or file extensions."""
     file_path = ensure_path_object(file_path)
     
     try:
@@ -34,9 +47,7 @@ def get_file_name(file_path: Union[str, Path]) -> str:
 
 
 def ensure_path_object(path: Union[str, Path]) -> Path:
-    """
-    Ensure the input is a Path object. If the input is a string, convert it to a Path object.
-    """
+    """Ensure the input is a Path object. If the input is a string, convert it to a Path object."""
     if not isinstance(path, Path):
         path = Path(path)
 

--- a/skelly_synchronize/utils/path_handling_utilities.py
+++ b/skelly_synchronize/utils/path_handling_utilities.py
@@ -1,0 +1,43 @@
+import logging
+from pathlib import Path
+from typing import Union
+
+logging.basicConfig(level=logging.INFO)
+
+def get_parent_directory(path: Union[str, Path]) -> Path:
+    path = ensure_path_object(path)
+
+    logging.info(f"Input path: {path}")
+
+    if path == path.parent:
+        logging.warning(f"Root directory detected, no parent directory. Returning {path}")
+        return path
+
+    parent_directory = path.parent
+    logging.info(f"Parent directory: {parent_directory}")
+
+    return parent_directory
+
+def get_file_name(file_path: Union[str, Path]) -> str:
+    """
+    Get the name of the file without directories or file extensions.
+    """
+    file_path = ensure_path_object(file_path)
+    
+    try:
+        file_name = file_path.stem
+        logging.info(f"Retrieved file name: {file_name} from path: {file_path}")
+        return file_name
+    except Exception as e:
+        logging.error(f"Error retrieving file name from path: {file_path}. Exception: {e}")
+        raise
+
+
+def ensure_path_object(path: Union[str, Path]) -> Path:
+    """
+    Ensure the input is a Path object. If the input is a string, convert it to a Path object.
+    """
+    if not isinstance(path, Path):
+        path = Path(path)
+
+    return path


### PR DESCRIPTION
This fixes #7 by consistently creating synchronized videos with the exact number of frames. It introduces a problem with videos recorded on iphones, but I'm in discussions with the deffcode maintainer to fix that issue. This branch is closer to functioning than main in that it does the core job of frame-perfect synchronization better. It also just generally cleans up the code quite a bit.