### PR TITLE
hot fix to prevent accidental switch to avg-frame-rate

### DIFF
--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -281,7 +281,7 @@ class VideoSynchronize:
                 "-select_streams",
                 "v:0",
                 "-show_entries",
-                "stream=avg_frame_rate",
+                "stream=r_frame_rate",
                 "-of",
                 "default=noprint_wrappers=1:nokey=1",
                 file_pathstring,


### PR DESCRIPTION
Accidentally switched the frame rate option in ffmpeg. I'm currently testing making this switch but it isn't stable for main yet.