### PR TITLE
Reattach audio once videos are saved

### DIFF
--- a/skelly_synchronize/core_processes/audio_utilities.py
+++ b/skelly_synchronize/core_processes/audio_utilities.py
@@ -63,6 +63,8 @@ def extract_audio_files(
 def trim_audio_files(
     audio_folder_path: Path, lag_dictionary: dict, synced_video_length: float
 ):
+    logging.info("Trimming audio files to match synchronized video length")
+
     trimmed_audio_folder_path = Path(audio_folder_path) / TRIMMED_AUDIO_FOLDER_NAME
     trimmed_audio_folder_path.mkdir(parents=True, exist_ok=True)
 
@@ -80,6 +82,7 @@ def trim_audio_files(
 
         audio_filename = str(audio_filepath.stem) + ".wav"
 
+        logging.info(f"Saving audio {audio_filename}")
         output_path = trimmed_audio_folder_path / audio_filename
         sf.write(output_path, shortened_audio_signal, sr, subtype="PCM_24")
 

--- a/skelly_synchronize/core_processes/audio_utilities.py
+++ b/skelly_synchronize/core_processes/audio_utilities.py
@@ -8,6 +8,7 @@ from typing import Dict
 from skelly_synchronize.core_processes.video_functions.ffmpeg_functions import (
     extract_audio_from_video_ffmpeg,
 )
+from skelly_synchronize.system.paths_and_file_names import TRIMMED_AUDIO_FOLDER_NAME
 
 
 def get_audio_sample_rates(audio_signal_dict: Dict[str, float]) -> list:
@@ -62,7 +63,7 @@ def extract_audio_files(
 def trim_audio_files(
     audio_folder_path: Path, lag_dictionary: dict, synced_video_length: float
 ):
-    trimmed_audio_folder_path = Path(audio_folder_path) / "trimmed_audio"
+    trimmed_audio_folder_path = Path(audio_folder_path) / TRIMMED_AUDIO_FOLDER_NAME
     trimmed_audio_folder_path.mkdir(parents=True, exist_ok=True)
 
     for audio_filepath in audio_folder_path.glob("*.wav"):

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -39,7 +39,7 @@ def get_audio_paths_from_folder(
     folder_path: Path, file_extension: str = ".wav"
 ) -> List[Path]:
     search_extension = "*" + file_extension.lower()
-    return list(Path(folder_path).glob(search_extension))
+    return Path(folder_path).glob(search_extension)
 
 
 def plot_waveforms(

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -7,30 +7,22 @@ from typing import List
 
 from skelly_synchronize.system.paths_and_file_names import (
     DEBUG_PLOT_NAME,
-    DEBUG_TOML_NAME,
     AUDIO_FILES_FOLDER_NAME,
-    LAG_DICTIONARY_NAME,
-    SYNCHRONIZED_VIDEO_NAME,
+    TRIMMED_AUDIO_FOLDER_NAME,
 )
 
 
 def create_debug_plots(synchronized_video_folder_path: Path):
     output_filepath = synchronized_video_folder_path / DEBUG_PLOT_NAME
-    audio_folder_path = synchronized_video_folder_path / AUDIO_FILES_FOLDER_NAME
-    debug_toml_path = synchronized_video_folder_path / DEBUG_TOML_NAME
-    debug_dictionary = toml.load(debug_toml_path)
+    raw_audio_folder_path = synchronized_video_folder_path / AUDIO_FILES_FOLDER_NAME
+    trimmed_audio_folder_path = raw_audio_folder_path / TRIMMED_AUDIO_FOLDER_NAME
 
-    # get a single video's duration from debug dictionary
-    arbitrary_video_information = next(
-        iter(debug_dictionary[SYNCHRONIZED_VIDEO_NAME].values())
-    )
-    video_duration = float(arbitrary_video_information["video duration"])
+    list_of_raw_audio_paths = get_audio_paths_from_folder(raw_audio_folder_path)
+    list_of_trimmed_audio_paths = get_audio_paths_from_folder(trimmed_audio_folder_path)
 
-    list_of_audio_paths = get_audio_paths_from_folder(audio_folder_path)
     plot_waveforms(
-        audio_filepath_list=list_of_audio_paths,
-        lag_dictionary=debug_dictionary[LAG_DICTIONARY_NAME],
-        synched_video_length=video_duration,
+        raw_audio_filepath_list=list_of_raw_audio_paths,
+        trimmed_audio_filepath_list=list_of_trimmed_audio_paths,
         output_filepath=output_filepath,
     )
 
@@ -43,9 +35,8 @@ def get_audio_paths_from_folder(
 
 
 def plot_waveforms(
-    audio_filepath_list: List[Path],
-    lag_dictionary: dict,
-    synched_video_length: float,
+    raw_audio_filepath_list: List[Path],
+    trimmed_audio_filepath_list: List[Path],
     output_filepath: Path,
 ):
     fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
@@ -58,24 +49,18 @@ def plot_waveforms(
     axs[0].set_title("Before Cross Correlation")
     axs[1].set_title("After Cross Correlation")
 
-    for audio_filepath in audio_filepath_list:
+    for audio_filepath in raw_audio_filepath_list:
         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
-        lag = lag_dictionary[audio_filepath.stem]
-
-        lag_in_samples = int(float(lag) * sr)
-        synched_video_length_in_samples = int(synched_video_length * sr)
-
-        shortened_audio_signal = audio_signal[lag_in_samples:]
-        shortened_audio_signal = shortened_audio_signal[
-            :synched_video_length_in_samples
-        ]
 
         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
-        shortened_time = np.linspace(
-            0, len(shortened_audio_signal) / sr, num=len(shortened_audio_signal)
-        )
 
         axs[0].plot(time, audio_signal, alpha=0.4)
-        axs[1].plot(shortened_time, shortened_audio_signal, alpha=0.4)
+
+    for audio_filepath in trimmed_audio_filepath_list:
+        audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
+
+        time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
+
+        axs[1].plot(time, audio_signal, alpha=0.4)
 
     plt.savefig(output_filepath)

--- a/skelly_synchronize/core_processes/video_functions/ffmpeg_functions.py
+++ b/skelly_synchronize/core_processes/video_functions/ffmpeg_functions.py
@@ -96,3 +96,31 @@ def trim_single_video_ffmpeg(
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
+
+
+def attach_audio_to_video_ffmpeg(
+    input_video_pathstring: str,
+    audio_file_pathstring: str,
+    output_video_pathstring: str,
+):
+    """Run a subprocess call to attach audio file back to the video"""
+
+    attach_audio_subprocess = subprocess.run(
+        [
+            "ffmpeg",
+            "-i",
+            f"{input_video_pathstring}",
+            "-i",
+            f"{audio_file_pathstring}",
+            "-c:v",
+            "copy",
+            "-c:a",
+            "aac",
+            f"{output_video_pathstring}",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    if attach_audio_subprocess.returncode != 0:
+        print(f"Error occurred: {attach_audio_subprocess.stderr.decode('utf-8')}")

--- a/skelly_synchronize/core_processes/video_functions/video_utilities.py
+++ b/skelly_synchronize/core_processes/video_functions/video_utilities.py
@@ -1,15 +1,18 @@
 import logging
 from pathlib import Path
 from typing import Dict
+from skelly_synchronize.core_processes.audio_utilities import trim_audio_files
+
 from skelly_synchronize.core_processes.video_functions.deffcode_functions import (
     trim_single_video_deffcode,
 )
-
 from skelly_synchronize.core_processes.video_functions.ffmpeg_functions import (
+    attach_audio_to_video_ffmpeg,
     extract_video_duration_ffmpeg,
     extract_video_fps_ffmpeg,
     trim_single_video_ffmpeg,
 )
+from skelly_synchronize.utils.get_video_files import get_video_file_list
 from skelly_synchronize.utils.path_handling_utilities import (
     name_synced_video,
 )
@@ -120,3 +123,30 @@ def find_minimum_video_duration(
     )
 
     return min_duration
+
+
+def attach_audio_to_videos(
+    synchronized_video_folder_path: Path,
+    audio_folder_path: Path,
+    lag_dictionary: dict,
+    synchronized_video_length: float,
+):
+    video_with_audio_path = Path(synchronized_video_folder_path) / "videos_with_audio"
+    video_with_audio_path.mkdir(parents=True, exist_ok=True)
+
+    trimmed_audio_folder_path = trim_audio_files(
+        audio_folder_path=audio_folder_path,
+        lag_dictionary=lag_dictionary,
+        synced_video_length=synchronized_video_length,
+    )
+
+    for video in get_video_file_list(synchronized_video_folder_path):
+        video_name = video.stem
+        audio_filename = f"{str(video_name).split('_')[-1]}.wav"
+        attach_audio_to_video_ffmpeg(
+            input_video_pathstring=str(video),
+            audio_file_pathstring=str(Path(trimmed_audio_folder_path) / audio_filename),
+            output_video_pathstring=str(
+                video_with_audio_path / f"{video_name}_with_audio.mp4"
+            ),
+        )

--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -12,6 +12,7 @@ from skelly_synchronize.core_processes.audio_utilities import (
 )
 from skelly_synchronize.core_processes.correlation_functions import find_lags
 from skelly_synchronize.core_processes.video_functions.video_utilities import (
+    attach_audio_to_videos,
     get_fps_list,
     create_video_info_dict,
     trim_videos,
@@ -121,6 +122,15 @@ def synchronize_videos_from_audio(
             LAG_DICTIONARY_NAME: lag_dict,
         },
         output_file_path=synchronized_video_folder_path / DEBUG_TOML_NAME,
+    )
+
+    attach_audio_to_videos(
+        synchronized_video_folder_path=synchronized_video_folder_path,
+        audio_folder_path=audio_folder_path,
+        lag_dictionary=lag_dict,
+        synchronized_video_length=next(iter(synchronized_video_info_dict.values()))[
+            "video duration"
+        ],
     )
 
     create_debug_plots(synchronized_video_folder_path=synchronized_video_folder_path)

--- a/skelly_synchronize/system/paths_and_file_names.py
+++ b/skelly_synchronize/system/paths_and_file_names.py
@@ -1,6 +1,7 @@
 # directory names
 SYNCHRONIZED_VIDEOS_FOLDER_NAME = "synchronized_videos"
 AUDIO_FILES_FOLDER_NAME = "audio_files"
+TRIMMED_AUDIO_FOLDER_NAME = "trimmed_audio"
 
 # file names
 DEBUG_TOML_NAME = "synchronization_debug.toml"

--- a/skelly_synchronize/utils/get_video_files.py
+++ b/skelly_synchronize/utils/get_video_files.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 
 
-def get_video_file_list(folder_path: Path, file_type: str) -> list:
+def get_video_file_list(folder_path: Path, file_type: str = "mp4") -> list:
     """Return a list of all video files in the base_path folder that match the given file type.
     file_type can be upper or lower case, with or without a leading period"""
 


### PR DESCRIPTION
Currently, the output videos are saved without sound due to opencv's video writer not supporting sound. This PR uses ffmpeg to trim and reattach the audio using ffmpeg so the user can get a video output with sound. On a sample session, it only added 2% to the processing time.

Tasks:
- [x] Reattach sound to videos
- [x] Overwrite the videos that don't have sound to reduce memory duplication
- [x] Use the reattached audio to create debug plots