### PR TITLE
Switch debug plotting to plotly to work in thread

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
 "opencv-contrib-python==4.6.0.66",
 "deffcode",
 "toml",
-"matplotlib"
+"matplotlib",
+"plotly"
 ] #add additional dependencies here - try to pin versions as minimally as possible
 
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ dependencies = [
 "opencv-contrib-python==4.6.0.66",
 "deffcode",
 "toml",
-"matplotlib",
-"plotly"
+"plotly",
+"kaleido"
 ] #add additional dependencies here - try to pin versions as minimally as possible
 
 requires-python = ">=3.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 deffcode==0.2.5
+kaleido==0.2.1
 librosa==0.10.0
-matplotlib==3.7.1
 numpy==1.21.5
 opencv-contrib-python==4.6.0.66
+plotly==5.15.0
 PyQt6==6.5.0
 pytest==7.1.2
 scipy==1.10.1

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -1,9 +1,12 @@
 import librosa
 import toml
-import matplotlib.pyplot as plt
+import matplotlib as mpl
 import numpy as np
 from pathlib import Path
 from typing import List
+
+mpl.use('Agg')
+import matplotlib.pyplot as plt
 
 from skelly_synchronize.system.paths_and_file_names import (
     DEBUG_PLOT_NAME,

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -5,7 +5,7 @@ import numpy as np
 from pathlib import Path
 from typing import List
 
-mpl.use('Agg')
+mpl.use("Agg")
 import matplotlib.pyplot as plt
 
 from skelly_synchronize.system.paths_and_file_names import (
@@ -42,7 +42,8 @@ def plot_waveforms(
     trimmed_audio_filepath_list: List[Path],
     output_filepath: Path,
 ):
-    with plt.subplots(2, 1, sharex=True, sharey=True) as (fig, axs):
+    with plt.figure() as fig:
+        axs = fig.subplots(2, 1, sharex=True, sharey=True)
         fig.suptitle("Audio Cross Correlation Debug")
 
         axs[0].set_ylabel("Amplitude")

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -42,29 +42,28 @@ def plot_waveforms(
     trimmed_audio_filepath_list: List[Path],
     output_filepath: Path,
 ):
-    with plt.figure() as fig:
-        axs = fig.subplots(2, 1, sharex=True, sharey=True)
-        fig.suptitle("Audio Cross Correlation Debug")
+    fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
+    fig.suptitle("Audio Cross Correlation Debug")
 
-        axs[0].set_ylabel("Amplitude")
-        axs[1].set_ylabel("Amplitude")
-        axs[1].set_xlabel("Time (s)")
+    axs[0].set_ylabel("Amplitude")
+    axs[1].set_ylabel("Amplitude")
+    axs[1].set_xlabel("Time (s)")
 
-        axs[0].set_title("Before Cross Correlation")
-        axs[1].set_title("After Cross Correlation")
+    axs[0].set_title("Before Cross Correlation")
+    axs[1].set_title("After Cross Correlation")
 
-        for audio_filepath in raw_audio_filepath_list:
-            audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
+    for audio_filepath in raw_audio_filepath_list:
+        audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
 
-            time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
+        time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
 
-            axs[0].plot(time, audio_signal, alpha=0.4)
+        axs[0].plot(time, audio_signal, alpha=0.4)
 
-        for audio_filepath in trimmed_audio_filepath_list:
-            audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
+    for audio_filepath in trimmed_audio_filepath_list:
+        audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
 
-            time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
+        time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
 
-            axs[1].plot(time, audio_signal, alpha=0.4)
+        axs[1].plot(time, audio_signal, alpha=0.4)
 
-        plt.savefig(output_filepath)
+    plt.savefig(output_filepath)

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -1,12 +1,15 @@
 import librosa
 import toml
-import matplotlib as mpl
+
+# import matplotlib as mpl
 import numpy as np
 from pathlib import Path
 from typing import List
+import plotly.graph_objects as go
+import plotly.subplots as sp
 
-mpl.use("Agg")
-import matplotlib.pyplot as plt
+# mpl.use("Agg")
+# import matplotlib.pyplot as plt
 
 from skelly_synchronize.system.paths_and_file_names import (
     DEBUG_PLOT_NAME,
@@ -37,33 +40,75 @@ def get_audio_paths_from_folder(
     return Path(folder_path).glob(search_extension)
 
 
+# def plot_waveforms(
+#     raw_audio_filepath_list: List[Path],
+#     trimmed_audio_filepath_list: List[Path],
+#     output_filepath: Path,
+# ):
+#     fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
+#     fig.suptitle("Audio Cross Correlation Debug")
+
+#     axs[0].set_ylabel("Amplitude")
+#     axs[1].set_ylabel("Amplitude")
+#     axs[1].set_xlabel("Time (s)")
+
+#     axs[0].set_title("Before Cross Correlation")
+#     axs[1].set_title("After Cross Correlation")
+
+#     for audio_filepath in raw_audio_filepath_list:
+#         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
+
+#         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
+
+#         axs[0].plot(time, audio_signal, alpha=0.4)
+
+#     for audio_filepath in trimmed_audio_filepath_list:
+#         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
+
+#         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
+
+#         axs[1].plot(time, audio_signal, alpha=0.4)
+
+#     plt.savefig(output_filepath)
+
+
 def plot_waveforms(
     raw_audio_filepath_list: List[Path],
     trimmed_audio_filepath_list: List[Path],
     output_filepath: Path,
 ):
-    fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
-    fig.suptitle("Audio Cross Correlation Debug")
+    # Create a subplot with 2 rows and 1 column
+    fig = sp.make_subplots(
+        rows=2,
+        cols=1,
+        shared_xaxes=True,
+        shared_yaxes=True,
+        subplot_titles=("Before Cross Correlation", "After Cross Correlation"),
+    )
 
-    axs[0].set_ylabel("Amplitude")
-    axs[1].set_ylabel("Amplitude")
-    axs[1].set_xlabel("Time (s)")
-
-    axs[0].set_title("Before Cross Correlation")
-    axs[1].set_title("After Cross Correlation")
-
+    # Plot raw audio waveforms
     for audio_filepath in raw_audio_filepath_list:
         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
-
         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
+        fig.add_trace(
+            go.Scatter(x=time, y=audio_signal, mode="lines", opacity=0.4), row=1, col=1
+        )
 
-        axs[0].plot(time, audio_signal, alpha=0.4)
-
+    # Plot trimmed audio waveforms
     for audio_filepath in trimmed_audio_filepath_list:
         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
-
         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
+        fig.add_trace(
+            go.Scatter(x=time, y=audio_signal, mode="lines", opacity=0.4), row=2, col=1
+        )
 
-        axs[1].plot(time, audio_signal, alpha=0.4)
+    # Update layout
+    fig.update_layout(
+        title="Audio Cross Correlation Debug",
+        yaxis1=dict(title="Amplitude"),
+        yaxis2=dict(title="Amplitude"),
+        xaxis2=dict(title="Time (s)"),
+    )
 
-    plt.savefig(output_filepath)
+    # Save to file
+    fig.write_image(str(output_filepath))

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -5,8 +5,13 @@ import numpy as np
 from pathlib import Path
 from typing import List
 
-mpl.use("Agg")
-import matplotlib.pyplot as plt
+# mpl.use("Agg")
+# import matplotlib.pyplot as plt
+
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
+import numpy as np
+from PIL import Image
 
 from skelly_synchronize.system.paths_and_file_names import (
     DEBUG_PLOT_NAME,
@@ -37,33 +42,69 @@ def get_audio_paths_from_folder(
     return Path(folder_path).glob(search_extension)
 
 
+# def plot_waveforms(
+#     raw_audio_filepath_list: List[Path],
+#     trimmed_audio_filepath_list: List[Path],
+#     output_filepath: Path,
+# ):
+#     fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
+#     fig.suptitle("Audio Cross Correlation Debug")
+
+#     axs[0].set_ylabel("Amplitude")
+#     axs[1].set_ylabel("Amplitude")
+#     axs[1].set_xlabel("Time (s)")
+
+#     axs[0].set_title("Before Cross Correlation")
+#     axs[1].set_title("After Cross Correlation")
+
+#     for audio_filepath in raw_audio_filepath_list:
+#         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
+
+#         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
+
+#         axs[0].plot(time, audio_signal, alpha=0.4)
+
+#     for audio_filepath in trimmed_audio_filepath_list:
+#         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
+
+#         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
+
+#         axs[1].plot(time, audio_signal, alpha=0.4)
+
+#     plt.savefig(output_filepath)
+
+
 def plot_waveforms(
     raw_audio_filepath_list: List[Path],
     trimmed_audio_filepath_list: List[Path],
     output_filepath: Path,
 ):
-    fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
+    fig = Figure(figsize=(10, 10), dpi=100)
+    canvas = FigureCanvasAgg(fig)
+
+    ax0 = fig.add_subplot(111)
+    ax1 = ax0.twinx()
     fig.suptitle("Audio Cross Correlation Debug")
 
-    axs[0].set_ylabel("Amplitude")
-    axs[1].set_ylabel("Amplitude")
-    axs[1].set_xlabel("Time (s)")
+    ax0.set_ylabel("Amplitude")
+    ax1.set_ylabel("Amplitude")
+    ax1.set_xlabel("Time (s)")
 
-    axs[0].set_title("Before Cross Correlation")
-    axs[1].set_title("After Cross Correlation")
+    ax0.set_title("Before Cross Correlation")
+    ax1.set_title("After Cross Correlation")
 
     for audio_filepath in raw_audio_filepath_list:
         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
 
         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
 
-        axs[0].plot(time, audio_signal, alpha=0.4)
+        ax0.plot(time, audio_signal, alpha=0.4)
 
     for audio_filepath in trimmed_audio_filepath_list:
         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
 
         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
 
-        axs[1].plot(time, audio_signal, alpha=0.4)
+        ax1.plot(time, audio_signal, alpha=0.4)
 
-    plt.savefig(output_filepath)
+    fig.savefig(output_filepath)

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -39,28 +39,28 @@ def plot_waveforms(
     trimmed_audio_filepath_list: List[Path],
     output_filepath: Path,
 ):
-    fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
-    fig.suptitle("Audio Cross Correlation Debug")
+    with plt.subplots(2, 1, sharex=True, sharey=True) as (fig, axs):
+        fig.suptitle("Audio Cross Correlation Debug")
 
-    axs[0].set_ylabel("Amplitude")
-    axs[1].set_ylabel("Amplitude")
-    axs[1].set_xlabel("Time (s)")
+        axs[0].set_ylabel("Amplitude")
+        axs[1].set_ylabel("Amplitude")
+        axs[1].set_xlabel("Time (s)")
 
-    axs[0].set_title("Before Cross Correlation")
-    axs[1].set_title("After Cross Correlation")
+        axs[0].set_title("Before Cross Correlation")
+        axs[1].set_title("After Cross Correlation")
 
-    for audio_filepath in raw_audio_filepath_list:
-        audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
+        for audio_filepath in raw_audio_filepath_list:
+            audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
 
-        time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
+            time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
 
-        axs[0].plot(time, audio_signal, alpha=0.4)
+            axs[0].plot(time, audio_signal, alpha=0.4)
 
-    for audio_filepath in trimmed_audio_filepath_list:
-        audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
+        for audio_filepath in trimmed_audio_filepath_list:
+            audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
 
-        time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
+            time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
 
-        axs[1].plot(time, audio_signal, alpha=0.4)
+            axs[1].plot(time, audio_signal, alpha=0.4)
 
-    plt.savefig(output_filepath)
+        plt.savefig(output_filepath)

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -1,15 +1,11 @@
 import librosa
 import toml
-
-# import matplotlib as mpl
 import numpy as np
-from pathlib import Path
-from typing import List
 import plotly.graph_objects as go
 import plotly.subplots as sp
-
-# mpl.use("Agg")
-# import matplotlib.pyplot as plt
+import plotly.colors as colors
+from pathlib import Path
+from typing import List
 
 from skelly_synchronize.system.paths_and_file_names import (
     DEBUG_PLOT_NAME,
@@ -40,38 +36,6 @@ def get_audio_paths_from_folder(
     return Path(folder_path).glob(search_extension)
 
 
-# def plot_waveforms(
-#     raw_audio_filepath_list: List[Path],
-#     trimmed_audio_filepath_list: List[Path],
-#     output_filepath: Path,
-# ):
-#     fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
-#     fig.suptitle("Audio Cross Correlation Debug")
-
-#     axs[0].set_ylabel("Amplitude")
-#     axs[1].set_ylabel("Amplitude")
-#     axs[1].set_xlabel("Time (s)")
-
-#     axs[0].set_title("Before Cross Correlation")
-#     axs[1].set_title("After Cross Correlation")
-
-#     for audio_filepath in raw_audio_filepath_list:
-#         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
-
-#         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
-
-#         axs[0].plot(time, audio_signal, alpha=0.4)
-
-#     for audio_filepath in trimmed_audio_filepath_list:
-#         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
-
-#         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
-
-#         axs[1].plot(time, audio_signal, alpha=0.4)
-
-#     plt.savefig(output_filepath)
-
-
 def plot_waveforms(
     raw_audio_filepath_list: List[Path],
     trimmed_audio_filepath_list: List[Path],
@@ -86,23 +50,41 @@ def plot_waveforms(
         subplot_titles=("Before Cross Correlation", "After Cross Correlation"),
     )
 
-    # Plot raw audio waveforms
-    for audio_filepath in raw_audio_filepath_list:
+    color_list = colors.DEFAULT_PLOTLY_COLORS
+
+    for idx, audio_filepath in enumerate(raw_audio_filepath_list):
         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
         fig.add_trace(
-            go.Scatter(x=time, y=audio_signal, mode="lines", opacity=0.4), row=1, col=1
+            go.Scatter(
+                name=audio_filepath.stem,
+                x=time,
+                y=audio_signal,
+                mode="lines",
+                opacity=0.4,
+                line=dict(color=color_list[idx % len(color_list)]),
+            ),
+            row=1,
+            col=1,
         )
 
-    # Plot trimmed audio waveforms
-    for audio_filepath in trimmed_audio_filepath_list:
+    for idx, audio_filepath in enumerate(trimmed_audio_filepath_list):
         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
         fig.add_trace(
-            go.Scatter(x=time, y=audio_signal, mode="lines", opacity=0.4), row=2, col=1
+            go.Scatter(
+                name=audio_filepath.stem,
+                x=time,
+                y=audio_signal,
+                mode="lines",
+                opacity=0.4,
+                line=dict(color=color_list[idx % len(color_list)]),
+                showlegend=False,
+            ),
+            row=2,
+            col=1,
         )
 
-    # Update layout
     fig.update_layout(
         title="Audio Cross Correlation Debug",
         yaxis1=dict(title="Amplitude"),
@@ -110,5 +92,4 @@ def plot_waveforms(
         xaxis2=dict(title="Time (s)"),
     )
 
-    # Save to file
     fig.write_image(str(output_filepath))

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -5,13 +5,8 @@ import numpy as np
 from pathlib import Path
 from typing import List
 
-# mpl.use("Agg")
-# import matplotlib.pyplot as plt
-
-from matplotlib.backends.backend_agg import FigureCanvasAgg
-from matplotlib.figure import Figure
-import numpy as np
-from PIL import Image
+mpl.use("Agg")
+import matplotlib.pyplot as plt
 
 from skelly_synchronize.system.paths_and_file_names import (
     DEBUG_PLOT_NAME,
@@ -42,69 +37,33 @@ def get_audio_paths_from_folder(
     return Path(folder_path).glob(search_extension)
 
 
-# def plot_waveforms(
-#     raw_audio_filepath_list: List[Path],
-#     trimmed_audio_filepath_list: List[Path],
-#     output_filepath: Path,
-# ):
-#     fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
-#     fig.suptitle("Audio Cross Correlation Debug")
-
-#     axs[0].set_ylabel("Amplitude")
-#     axs[1].set_ylabel("Amplitude")
-#     axs[1].set_xlabel("Time (s)")
-
-#     axs[0].set_title("Before Cross Correlation")
-#     axs[1].set_title("After Cross Correlation")
-
-#     for audio_filepath in raw_audio_filepath_list:
-#         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
-
-#         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
-
-#         axs[0].plot(time, audio_signal, alpha=0.4)
-
-#     for audio_filepath in trimmed_audio_filepath_list:
-#         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
-
-#         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
-
-#         axs[1].plot(time, audio_signal, alpha=0.4)
-
-#     plt.savefig(output_filepath)
-
-
 def plot_waveforms(
     raw_audio_filepath_list: List[Path],
     trimmed_audio_filepath_list: List[Path],
     output_filepath: Path,
 ):
-    fig = Figure(figsize=(10, 10), dpi=100)
-    canvas = FigureCanvasAgg(fig)
-
-    ax0 = fig.add_subplot(111)
-    ax1 = ax0.twinx()
+    fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
     fig.suptitle("Audio Cross Correlation Debug")
 
-    ax0.set_ylabel("Amplitude")
-    ax1.set_ylabel("Amplitude")
-    ax1.set_xlabel("Time (s)")
+    axs[0].set_ylabel("Amplitude")
+    axs[1].set_ylabel("Amplitude")
+    axs[1].set_xlabel("Time (s)")
 
-    ax0.set_title("Before Cross Correlation")
-    ax1.set_title("After Cross Correlation")
+    axs[0].set_title("Before Cross Correlation")
+    axs[1].set_title("After Cross Correlation")
 
     for audio_filepath in raw_audio_filepath_list:
         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
 
         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
 
-        ax0.plot(time, audio_signal, alpha=0.4)
+        axs[0].plot(time, audio_signal, alpha=0.4)
 
     for audio_filepath in trimmed_audio_filepath_list:
         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
 
         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
 
-        ax1.plot(time, audio_signal, alpha=0.4)
+        axs[1].plot(time, audio_signal, alpha=0.4)
 
-    fig.savefig(output_filepath)
+    plt.savefig(output_filepath)

--- a/skelly_synchronize/core_processes/video_functions/deffcode_functions.py
+++ b/skelly_synchronize/core_processes/video_functions/deffcode_functions.py
@@ -26,7 +26,7 @@ def trim_single_video_deffcode(
     decoder = FFdecoder(
         str(input_video_pathstring),
         frame_format="bgr24",
-        verbose=True,
+        verbose=False,
         **ffparams,
     ).formulate()
 

--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -46,7 +46,7 @@ def synchronize_videos_from_audio(
     synchronized_video_folder_path: Path = None,
     file_type: str = ".mp4",
     video_handler: str = "deffcode",
-    create_debug_plots: bool = True,
+    create_debug_plots_bool: bool = True,
 ):
     """Run the functions from the VideoSynchronize class to synchronize all videos with the given file type in the base path folder.
     Uses deffcode and to handle the video files as default, set "video_handler" to "ffmpeg" to use ffmpeg methods instead.
@@ -135,7 +135,7 @@ def synchronize_videos_from_audio(
             "video duration"
         ],
     )
-    if create_debug_plots:
+    if create_debug_plots_bool:
         create_debug_plots(synchronized_video_folder_path=synchronized_video_folder_path)
 
     end_timer = time.time()

--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -46,6 +46,7 @@ def synchronize_videos_from_audio(
     synchronized_video_folder_path: Path = None,
     file_type: str = ".mp4",
     video_handler: str = "deffcode",
+    create_debug_plots: bool = True,
 ):
     """Run the functions from the VideoSynchronize class to synchronize all videos with the given file type in the base path folder.
     Uses deffcode and to handle the video files as default, set "video_handler" to "ffmpeg" to use ffmpeg methods instead.
@@ -134,8 +135,8 @@ def synchronize_videos_from_audio(
             "video duration"
         ],
     )
-
-    create_debug_plots(synchronized_video_folder_path=synchronized_video_folder_path)
+    if create_debug_plots:
+        create_debug_plots(synchronized_video_folder_path=synchronized_video_folder_path)
 
     end_timer = time.time()
 

--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -136,7 +136,9 @@ def synchronize_videos_from_audio(
         ],
     )
     if create_debug_plots_bool:
-        create_debug_plots(synchronized_video_folder_path=synchronized_video_folder_path)
+        create_debug_plots(
+            synchronized_video_folder_path=synchronized_video_folder_path
+        )
 
     end_timer = time.time()
 


### PR DESCRIPTION
Running skelly_synchronize from a thread in Freemocap is failing due to matplotlib opening a gui. This PR switches the debug plotting to plotly, which is threadsafe. It also adds a parameter that allows turning off the debug plotting, if it's ever an issue in the future.

The commit log includes my attempts at getting matplotlib to work, but none of those changes made it to this version