### PR TITLE
Debug Changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,7 @@ dependencies = [
 "opencv-contrib-python==4.6.0.66",
 "deffcode",
 "toml",
-"plotly",
-"kaleido"
+"matplotlib",
 ] #add additional dependencies here - try to pin versions as minimally as possible
 
 requires-python = ">=3.8"

--- a/skelly_synchronize/__init__.py
+++ b/skelly_synchronize/__init__.py
@@ -14,6 +14,7 @@ __repo_issues_url__ = f"{__repo_url__}issues"
 import sys
 from pathlib import Path
 
+
 print(f"Thank you for using {__package_name__}!")
 print(f"This is printing from: {__file__}")
 print(f"Source code for this package is available at: {__repo_url__}")
@@ -25,6 +26,9 @@ sys.path.insert(0, str(base_package_path))  # add parent directory to sys.path
 from skelly_synchronize.system.default_paths import get_log_file_path
 from skelly_synchronize.system.logging_configuration import configure_logging
 from skelly_synchronize.skelly_synchronize import synchronize_videos_from_audio  # noqa
+from skelly_synchronize.core_processes.debugging.debug_plots import (
+    create_debug_plots,
+)  # noqa
 
 
 configure_logging(log_file_path=get_log_file_path())

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -36,9 +36,8 @@ def get_audio_paths_from_folder(
 
 
 def plot_waveforms(
-    audio_filepath_list: List[Path],
-    lag_dictionary: dict,
-    synched_video_length: float,
+    raw_audio_filepath_list: List[Path],
+    trimmed_audio_filepath_list: List[Path],
     output_filepath: Path,
 ):
     fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
@@ -51,25 +50,19 @@ def plot_waveforms(
     axs[0].set_title("Before Cross Correlation")
     axs[1].set_title("After Cross Correlation")
 
-    for audio_filepath in audio_filepath_list:
+    for audio_filepath in raw_audio_filepath_list:
         audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
-        lag = lag_dictionary[audio_filepath.stem]
-
-        lag_in_samples = int(float(lag) * sr)
-        synched_video_length_in_samples = int(synched_video_length * sr)
-
-        shortened_audio_signal = audio_signal[lag_in_samples:]
-        shortened_audio_signal = shortened_audio_signal[
-            :synched_video_length_in_samples
-        ]
 
         time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
-        shortened_time = np.linspace(
-            0, len(shortened_audio_signal) / sr, num=len(shortened_audio_signal)
-        )
 
         axs[0].plot(time, audio_signal, alpha=0.4)
-        axs[1].plot(shortened_time, shortened_audio_signal, alpha=0.4)
+
+    for audio_filepath in trimmed_audio_filepath_list:
+        audio_signal, sr = librosa.load(path=audio_filepath, sr=None)
+
+        time = np.linspace(0, len(audio_signal) / sr, num=len(audio_signal))
+
+        axs[1].plot(time, audio_signal, alpha=0.4)
 
     logging.info(f"Saving debug plots to: {output_filepath}")
     plt.savefig(output_filepath)

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -1,3 +1,4 @@
+import logging
 import librosa
 import numpy as np
 import plotly.graph_objects as go
@@ -90,5 +91,6 @@ def plot_waveforms(
         yaxis2=dict(title="Amplitude"),
         xaxis2=dict(title="Time (s)"),
     )
-
-    fig.write_image(str(output_filepath))
+    
+    logging.info("Saving plot to: " + str(output_filepath))
+    fig.write_image(str(output_filepath), engine="kaleido")


### PR DESCRIPTION
The switch to plotly is still causing problems with the freemocap integration, because plotly has a longstanding issue of hanging while trying to write an image to file. Because this hangs and doesn't throw an error, it is a fully breaking change. Because of this, we're switching back to using matplotlib for the plotting, and simply moving the plotting outside the thread in matplotlib. The `create_debug_plots_bool` allows you to turn off plotting if thread safety is a worry, and we've added the `create_debug_plots` function to the init file so it's accessible if you'd like to do the debug plotting in a separate thread