### PR TITLE
PATCH: fix error with underscores in video names

### DIFF
--- a/skelly_synchronize/core_processes/video_functions/video_utilities.py
+++ b/skelly_synchronize/core_processes/video_functions/video_utilities.py
@@ -144,7 +144,7 @@ def attach_audio_to_videos(
     ) as temp_dir:
         for video in get_video_file_list(synchronized_video_folder_path):
             video_name = video.stem
-            audio_filename = f"{str(video_name).split('_')[-1]}.wav"
+            audio_filename = f"{str(video_name).split('_', maxsplit=1)[-1]}.wav"
             output_video_pathstring = str(
                 Path(temp_dir) / f"{video_name}_with_audio_temp.mp4"
             )

--- a/skelly_synchronize/core_processes/video_functions/video_utilities.py
+++ b/skelly_synchronize/core_processes/video_functions/video_utilities.py
@@ -144,7 +144,10 @@ def attach_audio_to_videos(
     ) as temp_dir:
         for video in get_video_file_list(synchronized_video_folder_path):
             video_name = video.stem
-            audio_filename = f"{str(video_name).split('_', maxsplit=1)[-1]}.wav"
+            if video_name.startswith("synced_"):
+                audio_filename = f"{str(video_name).split('_', maxsplit=1)[-1]}.wav"
+            else:
+                audio_filename = video_name + ".wav"
             output_video_pathstring = str(
                 Path(temp_dir) / f"{video_name}_with_audio_temp.mp4"
             )


### PR DESCRIPTION
A discord user found synchronizing failed with videos that had underscores in video names. The issue was in the reattaching audio step, where the logic to remove `synced_` from the video name was splitting at all of the underscores in the name. I changed the logic to only split the first underscore, and to only do the splitting if the video name started with `synced_`, to be more robust for the future.