### PR TITLE
Update opencv to accept any version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 "numpy",
 "scipy",
 "setuptools",
-"opencv-contrib-python==4.6.0.66",
+"opencv-contrib-python",
 "deffcode",
 "toml",
 "matplotlib",


### PR DESCRIPTION
Previously we had to pin to `opencv-contrib-python=4.6.*` to not conflict with the freemocap charuco functions. Freemocap has since updated its charuco handling to allow newer versions of opencv, so we no longer need restrictive versioning.