### PR TITLE
Brightness synching

### DIFF
--- a/skelly_synchronize/__init__.py
+++ b/skelly_synchronize/__init__.py
@@ -27,7 +27,7 @@ from skelly_synchronize.system.default_paths import get_log_file_path
 from skelly_synchronize.system.logging_configuration import configure_logging
 from skelly_synchronize.skelly_synchronize import synchronize_videos_from_audio  # noqa
 from skelly_synchronize.core_processes.debugging.debug_plots import (
-    create_debug_plots,
+    create_audio_debug_plots,
 )  # noqa
 
 

--- a/skelly_synchronize/core_processes/correlation_functions.py
+++ b/skelly_synchronize/core_processes/correlation_functions.py
@@ -53,7 +53,7 @@ def find_first_brightness_change(
         logging.info(f"First brightness change detected at frame number {frame_number}")
     else:
         logging.info(
-            f"First brightness change not detected, defaulting to frame with largest detected brightness ratio"
+            f"First brightness change not detected, defaulting to frame with largest detected brightness ratio of {highest_brightness_ratio}"
         )
 
     return brightest_frame_yet
@@ -102,27 +102,21 @@ def find_cross_correlation_lags(
 
 
 def find_brightest_point_lags(
-    video_info_dict: dict, frame_rate: float
+    video_info_dict: dict, frame_rate: float, brightness_ratio_threshold: float = 3
 ) -> Dict[str, float]:
-    """Take a video info dictionary, find the first significant contrast change in the video, and return it's time in second as the lag.
+    """Take a video info dictionary, find the first significant contrast change in the video, and return its time in second as the lag.
     The lag dict is normalized so that the lag of the latest video to start in time is 0, and all other lags are positive.
     """
     lag_dict = {
-        video_dict["camera_name"]: find_first_brightness_change(
-            video_filepath=str(video_dict["video pathstring"]),
-            brightness_ratio_threshold=5,
+        video_dict["camera name"]: find_first_brightness_change(
+            video_pathstring=str(video_dict["video pathstring"]),
+            brightness_ratio_threshold=brightness_ratio_threshold,
         )
         / frame_rate
         for video_dict in video_info_dict.values()
     }
 
-    normalized_lag_dict = normalize_lag_dictionary(lag_dictionary=lag_dict)
-
-    logging.info(
-        f"original lag dict: {lag_dict} normalized lag dict: {normalized_lag_dict}"
-    )
-
-    return normalized_lag_dict
+    return lag_dict
 
 
 if __name__ == "__main__":

--- a/skelly_synchronize/core_processes/correlation_functions.py
+++ b/skelly_synchronize/core_processes/correlation_functions.py
@@ -30,19 +30,28 @@ def find_first_brightness_change(
     logging.info(f"Detecting first brightness change in {video_pathstring}")
     brightness_array = find_brightness_across_frames(video_pathstring)
     brightness_difference = np.diff(brightness_array, prepend=brightness_array[0])
-    brightness_double_difference = np.diff(brightness_difference, prepend=brightness_difference[0])
+    brightness_double_difference = np.diff(
+        brightness_difference, prepend=brightness_difference[0]
+    )
 
     combined_brightness_metric = brightness_difference * brightness_double_difference
 
-    first_brightness_change = np.argmax(combined_brightness_metric >= brightness_ratio_threshold)
+    first_brightness_change = np.argmax(
+        combined_brightness_metric >= brightness_ratio_threshold
+    )
 
     if first_brightness_change == 0:
-        logging.info("No brightness change exceeded threshold, defaulting to frame with fastest detected brightness change")
+        logging.info(
+            "No brightness change exceeded threshold, defaulting to frame with fastest detected brightness change"
+        )
         first_brightness_change = np.argmax(brightness_double_difference)
     else:
-        logging.info(f"First brightness change detected at frame number {first_brightness_change}")
+        logging.info(
+            f"First brightness change detected at frame number {first_brightness_change}"
+        )
 
     return first_brightness_change
+
 
 def find_brightness_across_frames(video_pathstring: str) -> np.array:
     video_capture_object = cv2.VideoCapture(video_pathstring)
@@ -59,7 +68,9 @@ def find_brightness_across_frames(video_pathstring: str) -> np.array:
         frame_number += 1
 
     video_path = Path(video_pathstring)
-    brightness_array_pathstring = str(video_path.parent / video_path.stem) + BRIGHTNESS_SUFFIX + ".npy"
+    brightness_array_pathstring = (
+        str(video_path.parent / video_path.stem) + BRIGHTNESS_SUFFIX + ".npy"
+    )
     np.save(file=brightness_array_pathstring, arr=brightness_array)
 
     return brightness_array

--- a/skelly_synchronize/core_processes/correlation_functions.py
+++ b/skelly_synchronize/core_processes/correlation_functions.py
@@ -5,6 +5,8 @@ import numpy as np
 from typing import Dict
 from scipy import signal
 
+from skelly_synchronize.system.paths_and_file_names import BRIGHTNESS_SUFFIX
+
 
 def cross_correlate(audio1, audio2):
     """Take two audio files, synchronize them using cross correlation, and trim them to the same length.
@@ -23,7 +25,7 @@ def cross_correlate(audio1, audio2):
 
 
 def find_first_brightness_change(
-    video_pathstring: str, brightness_ratio_threshold: float = 4
+    video_pathstring: str, brightness_ratio_threshold: float = 1000
 ) -> int:
     logging.info(f"Detecting first brightness change in {video_pathstring}")
     brightness_array = find_brightness_across_frames(video_pathstring)
@@ -56,9 +58,8 @@ def find_brightness_across_frames(video_pathstring: str) -> np.array:
         brightness_array[frame_number] = np.mean(gray_frame)
         frame_number += 1
 
-    #TODO: clean this up to put it in the synchronized video folder
     video_path = Path(video_pathstring)
-    brightness_array_pathstring = str(video_path.parent / video_path.stem) + "_brightness.npy"
+    brightness_array_pathstring = str(video_path.parent / video_path.stem) + BRIGHTNESS_SUFFIX + ".npy"
     np.save(file=brightness_array_pathstring, arr=brightness_array)
 
     return brightness_array
@@ -107,7 +108,7 @@ def find_cross_correlation_lags(
 
 
 def find_brightest_point_lags(
-    video_info_dict: dict, frame_rate: float, brightness_ratio_threshold: float = 3
+    video_info_dict: dict, frame_rate: float, brightness_ratio_threshold: float = 1000
 ) -> Dict[str, float]:
     """Take a video info dictionary, find the first significant contrast change in the video, and return its time in second as the lag.
     The lag dict is normalized so that the lag of the latest video to start in time is 0, and all other lags are positive.

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -6,13 +6,30 @@ from pathlib import Path
 from typing import List
 
 from skelly_synchronize.system.paths_and_file_names import (
+    BRIGHTNESS_SUFFIX,
     DEBUG_PLOT_NAME,
     AUDIO_FILES_FOLDER_NAME,
     TRIMMED_AUDIO_FOLDER_NAME,
 )
 
 
-def create_debug_plots(synchronized_video_folder_path: Path):
+def create_brightness_debug_plots(
+    raw_video_folder_path: Path, synchronized_video_folder_path: Path
+):
+    output_filepath = synchronized_video_folder_path / DEBUG_PLOT_NAME
+
+    list_of_raw_brightness_paths = get_brightness_npys_from_folder(folder_path=raw_video_folder_path)
+    list_of_trimmed_brightness_paths = get_brightness_npys_from_folder(folder_path=synchronized_video_folder_path)
+
+    logging.info("Creating debug plots")
+    plot_brightness_across_frames(
+        raw_brightness_npys=list_of_raw_brightness_paths,
+        trimmed_brightness_npys=list_of_trimmed_brightness_paths,
+        output_filepath=output_filepath,
+    )
+
+
+def create_audio_debug_plots(synchronized_video_folder_path: Path):
     output_filepath = synchronized_video_folder_path / DEBUG_PLOT_NAME
     raw_audio_folder_path = synchronized_video_folder_path / AUDIO_FILES_FOLDER_NAME
     trimmed_audio_folder_path = raw_audio_folder_path / TRIMMED_AUDIO_FOLDER_NAME
@@ -21,12 +38,18 @@ def create_debug_plots(synchronized_video_folder_path: Path):
     list_of_trimmed_audio_paths = get_audio_paths_from_folder(trimmed_audio_folder_path)
 
     logging.info("Creating debug plots")
-    plot_waveforms(
+    plot_audio_waveforms(
         raw_audio_filepath_list=list_of_raw_audio_paths,
         trimmed_audio_filepath_list=list_of_trimmed_audio_paths,
         output_filepath=output_filepath,
     )
 
+
+def get_brightness_npys_from_folder(
+    folder_path: Path
+) -> List[Path]:
+    search_extension = "*" + BRIGHTNESS_SUFFIX + ".npy"
+    return Path(folder_path).glob(search_extension)
 
 def get_audio_paths_from_folder(
     folder_path: Path, file_extension: str = ".wav"
@@ -35,7 +58,39 @@ def get_audio_paths_from_folder(
     return Path(folder_path).glob(search_extension)
 
 
-def plot_waveforms(
+def plot_brightness_across_frames(
+    raw_brightness_npys: List[Path],
+    trimmed_brightness_npys: List[Path],
+    output_filepath: Path,
+):
+    fig, axs = plt.subplots(2, 1, sharex=True, sharey=True)
+    fig.suptitle("Brightness Across Frames")
+
+    axs[0].set_ylabel("Brightness")
+    axs[1].set_ylabel("Brightness")
+    axs[1].set_xlabel("Time (s)")
+
+    axs[0].set_title("Before Cross Correlation")
+    axs[1].set_title("After Cross Correlation")
+
+    for brightness_npys in raw_brightness_npys:
+        brightness_array = np.load(brightness_npys)
+
+        time = np.linspace(0, len(brightness_array), num=len(brightness_array))
+
+        axs[0].plot(time, brightness_array, alpha=0.5)
+
+    for brightness_npys in trimmed_brightness_npys:
+        brightness_array = np.load(brightness_npys)
+
+        time = np.linspace(0, len(brightness_array), num=len(brightness_array))
+
+        axs[1].plot(time, brightness_array, alpha=0.5)
+
+    logging.info(f"Saving debug plots to: {output_filepath}")
+    plt.savefig(output_filepath)
+
+def plot_audio_waveforms(
     raw_audio_filepath_list: List[Path],
     trimmed_audio_filepath_list: List[Path],
     output_filepath: Path,

--- a/skelly_synchronize/core_processes/debugging/debug_plots.py
+++ b/skelly_synchronize/core_processes/debugging/debug_plots.py
@@ -18,8 +18,12 @@ def create_brightness_debug_plots(
 ):
     output_filepath = synchronized_video_folder_path / DEBUG_PLOT_NAME
 
-    list_of_raw_brightness_paths = get_brightness_npys_from_folder(folder_path=raw_video_folder_path)
-    list_of_trimmed_brightness_paths = get_brightness_npys_from_folder(folder_path=synchronized_video_folder_path)
+    list_of_raw_brightness_paths = get_brightness_npys_from_folder(
+        folder_path=raw_video_folder_path
+    )
+    list_of_trimmed_brightness_paths = get_brightness_npys_from_folder(
+        folder_path=synchronized_video_folder_path
+    )
 
     logging.info("Creating debug plots")
     plot_brightness_across_frames(
@@ -45,11 +49,10 @@ def create_audio_debug_plots(synchronized_video_folder_path: Path):
     )
 
 
-def get_brightness_npys_from_folder(
-    folder_path: Path
-) -> List[Path]:
+def get_brightness_npys_from_folder(folder_path: Path) -> List[Path]:
     search_extension = "*" + BRIGHTNESS_SUFFIX + ".npy"
     return Path(folder_path).glob(search_extension)
+
 
 def get_audio_paths_from_folder(
     folder_path: Path, file_extension: str = ".wav"
@@ -89,6 +92,7 @@ def plot_brightness_across_frames(
 
     logging.info(f"Saving debug plots to: {output_filepath}")
     plt.savefig(output_filepath)
+
 
 def plot_audio_waveforms(
     raw_audio_filepath_list: List[Path],

--- a/skelly_synchronize/gui/skelly_synchronize_gui.py
+++ b/skelly_synchronize/gui/skelly_synchronize_gui.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from PyQt6.QtGui import QDoubleValidator
 from PyQt6.QtWidgets import (
     QApplication,
     QWidget,
@@ -7,6 +8,8 @@ from PyQt6.QtWidgets import (
     QFileDialog,
     QMainWindow,
     QLabel,
+    QLineEdit,
+    QHBoxLayout
 )
 
 from gui.widgets.run_button_widget import RunButtonWidget
@@ -51,10 +54,22 @@ class MainWindow(QMainWindow):
         )
         self.run_brightness_synch_button.setEnabled(False)
         self._layout.addWidget(self.run_brightness_synch_button)
+
+        hbox = QHBoxLayout()
+        brightness_threshold_default = 4
+        hbox.addWidget(QLabel("Brightness ratio threshold: "))
+        self.brightness_threshold_lineedit = QLineEdit()
+        self.brightness_threshold_lineedit.setText(str(brightness_threshold_default))
+        validator = QDoubleValidator()
+        validator.setBottom(1)
+        self.brightness_threshold_lineedit.setValidator(validator)
+        hbox.addWidget(self.brightness_threshold_lineedit)
+        self._layout.addLayout(hbox)
+
         self.run_brightness_synch_button.clicked.connect(
             lambda: synchronize_videos_from_brightness(
                 raw_video_folder_path=self._folder_path,
-                brightness_ratio_threshold=1.2,
+                brightness_ratio_threshold=float(self.brightness_threshold_lineedit.text()),
             )
         )
 

--- a/skelly_synchronize/gui/skelly_synchronize_gui.py
+++ b/skelly_synchronize/gui/skelly_synchronize_gui.py
@@ -9,11 +9,14 @@ from PyQt6.QtWidgets import (
     QMainWindow,
     QLabel,
     QLineEdit,
-    QHBoxLayout
+    QHBoxLayout,
 )
 
 from gui.widgets.run_button_widget import RunButtonWidget
-from skelly_synchronize.skelly_synchronize import synchronize_videos_from_audio, synchronize_videos_from_brightness
+from skelly_synchronize.skelly_synchronize import (
+    synchronize_videos_from_audio,
+    synchronize_videos_from_brightness,
+)
 
 
 class MainWindow(QMainWindow):
@@ -69,7 +72,9 @@ class MainWindow(QMainWindow):
         self.run_brightness_synch_button.clicked.connect(
             lambda: synchronize_videos_from_brightness(
                 raw_video_folder_path=self._folder_path,
-                brightness_ratio_threshold=float(self.brightness_threshold_lineedit.text()),
+                brightness_ratio_threshold=float(
+                    self.brightness_threshold_lineedit.text()
+                ),
             )
         )
 

--- a/skelly_synchronize/gui/skelly_synchronize_gui.py
+++ b/skelly_synchronize/gui/skelly_synchronize_gui.py
@@ -56,7 +56,7 @@ class MainWindow(QMainWindow):
         self._layout.addWidget(self.run_brightness_synch_button)
 
         hbox = QHBoxLayout()
-        brightness_threshold_default = 4
+        brightness_threshold_default = 1000
         hbox.addWidget(QLabel("Brightness ratio threshold: "))
         self.brightness_threshold_lineedit = QLineEdit()
         self.brightness_threshold_lineedit.setText(str(brightness_threshold_default))

--- a/skelly_synchronize/gui/skelly_synchronize_gui.py
+++ b/skelly_synchronize/gui/skelly_synchronize_gui.py
@@ -10,7 +10,7 @@ from PyQt6.QtWidgets import (
 )
 
 from gui.widgets.run_button_widget import RunButtonWidget
-from skelly_synchronize.skelly_synchronize import synchronize_videos_from_audio
+from skelly_synchronize.skelly_synchronize import synchronize_videos_from_audio, synchronize_videos_from_brightness
 
 
 class MainWindow(QMainWindow):
@@ -35,12 +35,26 @@ class MainWindow(QMainWindow):
         self.folder_path_label.setFixedHeight(15)
         self._layout.addWidget(self.folder_path_label)
 
-        self.run_button = RunButtonWidget()
-        self.run_button.run_button_widget.setEnabled(False)
-        self._layout.addWidget(self.run_button)
-        self.run_button.run_button_widget.clicked.connect(
+        self.run_audio_synch_button = QPushButton(
+            "Synchronize videos with Audio Cross Correlation"
+        )
+        self.run_audio_synch_button.setEnabled(False)
+        self._layout.addWidget(self.run_audio_synch_button)
+        self.run_audio_synch_button.clicked.connect(
             lambda: synchronize_videos_from_audio(
                 raw_video_folder_path=self._folder_path
+            )
+        )
+
+        self.run_brightness_synch_button = QPushButton(
+            "Synchronize videos with First Brightness Change"
+        )
+        self.run_brightness_synch_button.setEnabled(False)
+        self._layout.addWidget(self.run_brightness_synch_button)
+        self.run_brightness_synch_button.clicked.connect(
+            lambda: synchronize_videos_from_brightness(
+                raw_video_folder_path=self._folder_path,
+                brightness_ratio_threshold=1.2,
             )
         )
 
@@ -50,7 +64,8 @@ class MainWindow(QMainWindow):
         self.folder_path_label.setText(
             f"Selected folder of raw videos: {self._folder_path}"
         )
-        self.run_button.run_button_widget.setEnabled(True)
+        self.run_audio_synch_button.setEnabled(True)
+        self.run_brightness_synch_button.setEnabled(True)
 
 
 def main():

--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -1,7 +1,10 @@
 import time
 import logging
 from pathlib import Path
-from skelly_synchronize.core_processes.debugging.debug_plots import create_audio_debug_plots, create_brightness_debug_plots
+from skelly_synchronize.core_processes.debugging.debug_plots import (
+    create_audio_debug_plots,
+    create_brightness_debug_plots,
+)
 
 from skelly_synchronize.utils.get_video_files import get_video_file_list
 from skelly_synchronize.core_processes.audio_utilities import (
@@ -166,7 +169,9 @@ def synchronize_videos_from_brightness(
     """
     start_timer = time.time()
 
-    logging.info(f"Synchronizing videos with a brightness ratio threshold of {brightness_ratio_threshold}")
+    logging.info(
+        f"Synchronizing videos with a brightness ratio threshold of {brightness_ratio_threshold}"
+    )
 
     video_file_list = get_video_file_list(
         folder_path=raw_video_folder_path, file_type=file_type
@@ -191,7 +196,9 @@ def synchronize_videos_from_brightness(
 
     # find the lags between starting times
     lag_dict = find_brightest_point_lags(
-        video_info_dict=video_info_dict, frame_rate=fps, brightness_ratio_threshold=brightness_ratio_threshold
+        video_info_dict=video_info_dict,
+        frame_rate=fps,
+        brightness_ratio_threshold=brightness_ratio_threshold,
     )
 
     trim_videos(
@@ -230,7 +237,7 @@ def synchronize_videos_from_brightness(
     if create_debug_plots_bool:
         create_brightness_debug_plots(
             raw_video_folder_path=raw_video_folder_path,
-            synchronized_video_folder_path=synchronized_video_folder_path
+            synchronized_video_folder_path=synchronized_video_folder_path,
         )
 
     end_timer = time.time()

--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -164,6 +164,8 @@ def synchronize_videos_from_brightness(
     """
     start_timer = time.time()
 
+    logging.info(f"Synchronizing videos with a brightness ratio threshold of {brightness_ratio_threshold}")
+
     video_file_list = get_video_file_list(
         folder_path=raw_video_folder_path, file_type=file_type
     )

--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -1,7 +1,7 @@
 import time
 import logging
 from pathlib import Path
-from skelly_synchronize.core_processes.debugging.debug_plots import create_debug_plots
+from skelly_synchronize.core_processes.debugging.debug_plots import create_audio_debug_plots, create_brightness_debug_plots
 
 from skelly_synchronize.utils.get_video_files import get_video_file_list
 from skelly_synchronize.core_processes.audio_utilities import (
@@ -10,6 +10,7 @@ from skelly_synchronize.core_processes.audio_utilities import (
 )
 from skelly_synchronize.core_processes.correlation_functions import (
     find_brightest_point_lags,
+    find_brightness_across_frames,
     find_cross_correlation_lags,
 )
 from skelly_synchronize.core_processes.video_functions.video_utilities import (
@@ -139,7 +140,7 @@ def synchronize_videos_from_audio(
         ],
     )
     if create_debug_plots_bool:
-        create_debug_plots(
+        create_audio_debug_plots(
             synchronized_video_folder_path=synchronized_video_folder_path
         )
 
@@ -155,7 +156,8 @@ def synchronize_videos_from_brightness(
     synchronized_video_folder_path: Path = None,
     file_type: str = ".mp4",
     video_handler: str = "deffcode",
-    brightness_ratio_threshold: float = 3,
+    brightness_ratio_threshold: float = 1000,
+    create_debug_plots_bool: bool = True,
 ):
     """Synchronize all videos with the given file type in the base path folder using the first frame in each video with a high change in brightness between frames.
     Uses deffcode and to handle the video files as default, set "video_handler" to "ffmpeg" to use ffmpeg methods instead.
@@ -221,6 +223,15 @@ def synchronize_videos_from_brightness(
         },
         output_file_path=synchronized_video_folder_path / DEBUG_TOML_NAME,
     )
+
+    for video_dict in synchronized_video_info_dict.values():
+        find_brightness_across_frames(video_pathstring=video_dict["video pathstring"])
+
+    if create_debug_plots_bool:
+        create_brightness_debug_plots(
+            raw_video_folder_path=raw_video_folder_path,
+            synchronized_video_folder_path=synchronized_video_folder_path
+        )
 
     end_timer = time.time()
 

--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -8,7 +8,10 @@ from skelly_synchronize.core_processes.audio_utilities import (
     extract_audio_files,
     get_audio_sample_rates,
 )
-from skelly_synchronize.core_processes.correlation_functions import find_lags
+from skelly_synchronize.core_processes.correlation_functions import (
+    find_brightest_point_lags,
+    find_cross_correlation_lags,
+)
 from skelly_synchronize.core_processes.video_functions.video_utilities import (
     attach_audio_to_videos,
     get_fps_list,
@@ -48,7 +51,7 @@ def synchronize_videos_from_audio(
     video_handler: str = "deffcode",
     create_debug_plots_bool: bool = True,
 ):
-    """Run the functions from the VideoSynchronize class to synchronize all videos with the given file type in the base path folder.
+    """Synchronize all videos with the given file type in the base path folder using audio cross correlation.
     Uses deffcode and to handle the video files as default, set "video_handler" to "ffmpeg" to use ffmpeg methods instead.
     ffmpeg is used to get audio from the video files with either method.
 
@@ -90,7 +93,7 @@ def synchronize_videos_from_audio(
     audio_sample_rate = check_list_values_are_equal(input_list=audio_sample_rates)
 
     # find the lags between starting times
-    lag_dict = find_lags(
+    lag_dict = find_cross_correlation_lags(
         audio_signal_dict=audio_signal_dict, sample_rate=audio_sample_rate
     )
 
@@ -139,6 +142,80 @@ def synchronize_videos_from_audio(
         create_debug_plots(
             synchronized_video_folder_path=synchronized_video_folder_path
         )
+
+    end_timer = time.time()
+
+    logging.info(f"Elapsed processing time in seconds: {end_timer - start_timer}")
+
+    return synchronized_video_folder_path
+
+
+def synchronize_videos_from_brightness(
+    raw_video_folder_path: Path,
+    synchronized_video_folder_path: Path = None,
+    file_type: str = ".mp4",
+    video_handler: str = "deffcode",
+):
+    """Synchronize all videos with the given file type in the base path folder using the first frame in each video with a high change in brightness between frames.
+    Uses deffcode and to handle the video files as default, set "video_handler" to "ffmpeg" to use ffmpeg methods instead.
+
+    Returns the folder path of the synchronized video folder.
+    """
+    start_timer = time.time()
+
+    video_file_list = get_video_file_list(
+        folder_path=raw_video_folder_path, file_type=file_type
+    )
+    if synchronized_video_folder_path is None:
+        synchronized_video_folder_path = create_directory(
+            parent_directory=raw_video_folder_path.parent,
+            directory_name=SYNCHRONIZED_VIDEOS_FOLDER_NAME,
+        )
+    synchronized_video_folder_path = Path(synchronized_video_folder_path)
+
+    # create dictionaries with video
+    video_info_dict = create_video_info_dict(
+        video_filepath_list=video_file_list, video_handler="ffmpeg"
+    )
+
+    # get video fps
+    fps_list = get_fps_list(video_info_dict=video_info_dict)
+
+    # frame rates must be the same duration for the trimming process to work correctly
+    fps = check_list_values_are_equal(input_list=fps_list)
+
+    # find the lags between starting times
+    lag_dict = find_brightest_point_lags
+
+    trim_videos(
+        video_info_dict=video_info_dict,
+        synchronized_folder_path=synchronized_video_folder_path,
+        lag_dict=lag_dict,
+        fps=fps,
+        video_handler=video_handler,
+    )
+
+    synchronized_video_framecounts = get_number_of_frames_of_videos_in_a_folder(
+        folder_path=synchronized_video_folder_path
+    )
+    logging.info(
+        f"All videos are {check_list_values_are_equal(synchronized_video_framecounts)} frames long"
+    )
+
+    synchronized_video_info_dict = create_video_info_dict(
+        video_filepath_list=get_video_file_list(
+            synchronized_video_folder_path, file_type=file_type
+        )
+    )
+
+    save_dictionaries_to_toml(
+        input_dictionaries={
+            RAW_VIDEO_NAME: video_info_dict,
+            SYNCHRONIZED_VIDEO_NAME: synchronized_video_info_dict,
+            LAG_DICTIONARY_NAME: lag_dict,
+        },
+        output_file_path=synchronized_video_folder_path / DEBUG_TOML_NAME,
+    )
 
     end_timer = time.time()
 

--- a/skelly_synchronize/skelly_synchronize.py
+++ b/skelly_synchronize/skelly_synchronize.py
@@ -155,6 +155,7 @@ def synchronize_videos_from_brightness(
     synchronized_video_folder_path: Path = None,
     file_type: str = ".mp4",
     video_handler: str = "deffcode",
+    brightness_ratio_threshold: float = 3,
 ):
     """Synchronize all videos with the given file type in the base path folder using the first frame in each video with a high change in brightness between frames.
     Uses deffcode and to handle the video files as default, set "video_handler" to "ffmpeg" to use ffmpeg methods instead.
@@ -185,7 +186,9 @@ def synchronize_videos_from_brightness(
     fps = check_list_values_are_equal(input_list=fps_list)
 
     # find the lags between starting times
-    lag_dict = find_brightest_point_lags
+    lag_dict = find_brightest_point_lags(
+        video_info_dict=video_info_dict, frame_rate=fps, brightness_ratio_threshold=brightness_ratio_threshold
+    )
 
     trim_videos(
         video_info_dict=video_info_dict,

--- a/skelly_synchronize/system/paths_and_file_names.py
+++ b/skelly_synchronize/system/paths_and_file_names.py
@@ -17,3 +17,7 @@ LAG_DICTIONARY_NAME = "Lag_dictionary"
 # figshare info
 FIGSHARE_ZIP_FILE_URL = "https://figshare.com/ndownloader/files/41066489"
 FIGSHARE_SAMPLE_DATA_FILE_NAME = "skelly_synchronize_sample_data"
+
+# string constants
+SYNCED_VIDEO_PRECURSOR = "synced_"
+BRIGHTNESS_SUFFIX = "_brightness"

--- a/skelly_synchronize/utils/path_handling_utilities.py
+++ b/skelly_synchronize/utils/path_handling_utilities.py
@@ -1,6 +1,8 @@
 import logging
 from pathlib import Path
 
+from skelly_synchronize.system.paths_and_file_names import SYNCED_VIDEO_PRECURSOR
+
 logging.basicConfig(level=logging.INFO)
 
 
@@ -23,8 +25,8 @@ def name_synced_video(raw_video_filename: str) -> str:
     """Take a raw video filename, remove the raw prefix if its there, and return the synced video filename"""
     raw_video_filename = str(raw_video_filename)
     if raw_video_filename.split("_")[0] == "raw":
-        synced_video_name = "synced_" + raw_video_filename[4:] + ".mp4"
+        synced_video_name = SYNCED_VIDEO_PRECURSOR + raw_video_filename[4:] + ".mp4"
     else:
-        synced_video_name = "synced_" + raw_video_filename + ".mp4"
+        synced_video_name = SYNCED_VIDEO_PRECURSOR + raw_video_filename + ".mp4"
 
     return synced_video_name


### PR DESCRIPTION
This PR adds the ability to synchronize videos based on a bright flash of light. The synchronization step looks for the frame with the maximum increase in brightness from the frame before, and the maximum speed of brightness increase. Including the speed of brightness increase helps prevent other brightness changes, like walking in front of a camera, from being picked up as the brightness change.

The synchronization will work better with light sources that are brighter and can be switched on faster (a camera flash or lamp will work better than something like opening curtains).

The idea and original implementation of this method came from freemocap contributor @ajc27

Debug plot from a sample session:
![debug_plot](https://github.com/freemocap/skelly_synchronize/assets/24758117/0df34292-82ad-4a53-97f5-073e3f132ce5)
