### PR TITLE
Normalize framerates

### DIFF
--- a/skelly_synchronize/core_processes/audio_utilities.py
+++ b/skelly_synchronize/core_processes/audio_utilities.py
@@ -7,15 +7,16 @@ from typing import Dict
 
 from skelly_synchronize.core_processes.video_functions.ffmpeg_functions import (
     extract_audio_from_video_ffmpeg,
+    extract_audio_sample_rate_ffmpeg,
 )
 from skelly_synchronize.system.paths_and_file_names import TRIMMED_AUDIO_FOLDER_NAME
 
 
-def get_audio_sample_rates(audio_signal_dict: Dict[str, float]) -> list:
+def get_audio_sample_rates(video_info_dict: Dict[str, dict]) -> list:
     """Get the sample rates of each audio file and return them in a list"""
     audio_sample_rate_list = [
-        single_audio_dict["sample rate"]
-        for single_audio_dict in audio_signal_dict.values()
+        extract_audio_sample_rate_ffmpeg(file_pathstring=video_dict["video pathstring"])
+        for video_dict in video_info_dict.values()
     ]
 
     return audio_sample_rate_list

--- a/skelly_synchronize/core_processes/normalize_framerates.py
+++ b/skelly_synchronize/core_processes/normalize_framerates.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from typing import Dict, List
+from skelly_synchronize.core_processes.video_functions.ffmpeg_functions import (
+    normalize_framerates_in_video_ffmpeg,
+)
+from skelly_synchronize.system.paths_and_file_names import NORMALIZED_VIDEOS_FOLDER_NAME
+
+from skelly_synchronize.utils.path_handling_utilities import create_directory
+
+
+def normalize_framerates(
+    raw_video_folder_path: Path,
+    video_info_dict: Dict[str, dict],
+    fps_list: List[float],
+    audio_samplerate_list: List[float] = None,
+) -> Path:
+    """Normalize the frame rates of a list of videos. Also normalize audio sample rates, if given"""
+    normalized_videos_folder_path = create_directory(
+        parent_directory=raw_video_folder_path,
+        directory_name=NORMALIZED_VIDEOS_FOLDER_NAME,
+    )
+
+    fps_list.sort()
+    desired_fps = min(fps_list)
+
+    if audio_samplerate_list is not None:
+        audio_samplerate_list.sort()
+        desired_audio_sample_rate = min(audio_samplerate_list)
+    else:
+        desired_audio_sample_rate = 44100
+
+    for video_dict in video_info_dict.values():
+        normalize_framerates_in_video_ffmpeg(
+            input_video_pathstring=str(video_dict["video pathstring"]),
+            output_video_pathstring=str(
+                normalized_videos_folder_path / f"{video_dict['camera name']}.mp4"
+            ),
+            desired_fps=desired_fps,
+            desired_sample_rate=desired_audio_sample_rate,
+        )
+
+    return normalized_videos_folder_path

--- a/skelly_synchronize/core_processes/video_functions/ffmpeg_functions.py
+++ b/skelly_synchronize/core_processes/video_functions/ffmpeg_functions.py
@@ -73,6 +73,63 @@ def extract_video_fps_ffmpeg(file_pathstring: str):
     return video_fps
 
 
+def extract_audio_sample_rate_ffmpeg(file_pathstring: str):
+    """Run a subprocess call to get the audio sample rate of a video file using ffmpeg"""
+
+    extract_sample_rate_subprocess = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "stream=sample_rate",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            file_pathstring,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    # get the result, then remove the excess characters to get something like '####'
+    cleaned_stdout = (
+        str(extract_sample_rate_subprocess.stdout).split("'")[1].split("\\")[0]
+    )
+    # convert to float
+    audio_sample_rate = float(cleaned_stdout)
+
+    return audio_sample_rate
+
+
+def normalize_framerates_in_video_ffmpeg(
+    input_video_pathstring: str,
+    output_video_pathstring: str,
+    desired_fps: float = 30,
+    desired_sample_rate: int = 44100,
+):
+    """Run a subprocess call to normalize the framerate and audio sample rate of a video file using ffmpeg"""
+
+    normalize_framerates_subprocess = subprocess.run(
+        [
+            "ffmpeg",
+            "-i",
+            f"{input_video_pathstring}",
+            "-r",
+            f"{desired_fps}",
+            "-ar",
+            f"{desired_sample_rate}",
+            "-y",
+            f"{output_video_pathstring}",
+        ]
+    )
+
+    if normalize_framerates_subprocess.returncode != 0:
+        raise Exception(
+            f"ffmpeg returned code {normalize_framerates_subprocess.returncode}"
+        )
+
+
 def trim_single_video_ffmpeg(
     input_video_pathstring: str,
     start_time: float,

--- a/skelly_synchronize/core_processes/video_functions/video_utilities.py
+++ b/skelly_synchronize/core_processes/video_functions/video_utilities.py
@@ -27,9 +27,9 @@ def create_video_info_dict(
     video_info_dict = dict()
     for video_filepath in video_filepath_list:
         video_dict = dict()
-        video_dict["video filepath"] = video_filepath
+        video_dict["video filepath"] = Path(video_filepath)
         video_dict["video pathstring"] = str(video_filepath)
-        video_name = video_filepath.stem
+        video_name = Path(video_filepath).stem
         video_dict["camera name"] = video_name
 
         if video_handler == "ffmpeg":
@@ -103,7 +103,7 @@ def trim_videos(
 
 
 def get_fps_list(video_info_dict: Dict[str, dict]):
-    """Get list of the frames per second in earch video"""
+    """Get list of the frames per second in each video"""
     return [video_dict["video fps"] for video_dict in video_info_dict.values()]
 
 

--- a/skelly_synchronize/system/paths_and_file_names.py
+++ b/skelly_synchronize/system/paths_and_file_names.py
@@ -3,6 +3,7 @@ SYNCHRONIZED_VIDEOS_FOLDER_NAME = "synchronized_videos"
 RAW_VIDEOS_FOLDER_NAME = "raw_videos"
 AUDIO_FILES_FOLDER_NAME = "audio_files"
 TRIMMED_AUDIO_FOLDER_NAME = "trimmed_audio"
+NORMALIZED_VIDEOS_FOLDER_NAME = "normalized_videos"
 
 # file names
 DEBUG_TOML_NAME = "synchronization_debug.toml"

--- a/skelly_synchronize/tests/conftest.py
+++ b/skelly_synchronize/tests/conftest.py
@@ -26,7 +26,7 @@ def pytest_sessionstart():
         pytest.raw_video_folder_path
     )
     pytest.video_file_list = get_video_file_list(
-        folder_path=pytest.synchronized_video_folder_path, file_type=".mp4"
+        folder_path=pytest.synchronized_video_folder_path
     )
 
 

--- a/skelly_synchronize/tests/utilities/get_number_of_frames_of_videos_in_a_folder.py
+++ b/skelly_synchronize/tests/utilities/get_number_of_frames_of_videos_in_a_folder.py
@@ -20,9 +20,7 @@ def get_number_of_frames_of_videos_in_a_folder(folder_path: Union[str, Path]):
     Get the number of frames in the first video in a folder
     """
 
-    list_of_video_paths = get_video_file_list(
-        folder_path=Path(folder_path)
-    )
+    list_of_video_paths = get_video_file_list(folder_path=Path(folder_path))
 
     if len(list_of_video_paths) == 0:
         logger.error(f"No videos found in {folder_path}")

--- a/skelly_synchronize/tests/utilities/get_number_of_frames_of_videos_in_a_folder.py
+++ b/skelly_synchronize/tests/utilities/get_number_of_frames_of_videos_in_a_folder.py
@@ -21,7 +21,7 @@ def get_number_of_frames_of_videos_in_a_folder(folder_path: Union[str, Path]):
     """
 
     list_of_video_paths = get_video_file_list(
-        folder_path=Path(folder_path), file_type=".mp4"
+        folder_path=Path(folder_path)
     )
 
     if len(list_of_video_paths) == 0:

--- a/skelly_synchronize/utils/get_video_files.py
+++ b/skelly_synchronize/utils/get_video_files.py
@@ -2,17 +2,18 @@ import logging
 from pathlib import Path
 
 
-def get_video_file_list(folder_path: Path, file_type: str = "mp4") -> list:
-    """Return a list of all video files in the base_path folder that match the given file type.
-    file_type can be upper or lower case, with or without a leading period"""
+def get_video_file_list(folder_path: Path) -> list:
+    """Return a list of all video files in the base_path folder that match a video file type"""
+    list_of_video_formats = ["mp4", "mkv", "avi", "mpeg", "mov"]
 
-    # create general search from file type to use in glob search, including cases for upper and lowercase file types
-    file_extension_upper = "*" + file_type.upper()
-    file_extension_lower = "*" + file_type.lower()
-    # make list of all files with file type
-    video_filepath_list = list(folder_path.glob(file_extension_upper)) + list(
-        folder_path.glob(file_extension_lower)
-    )  # if two capitalization standards are used, the videos may not be in original order
+    video_filepath_list = []
+    for file_type in list_of_video_formats:
+        file_extension_upper = "*" + file_type.upper()
+        file_extension_lower = "*" + file_type.lower()
+
+        video_filepath_list.extend(list(folder_path.glob(file_extension_upper)))
+        video_filepath_list.extend(list(folder_path.glob(file_extension_lower)))
+
     # because glob behaves differently on windows vs. mac/linux, we collect all files both upper and lowercase, and remove redundant files that appear on windows
     unique_video_filepath_list = get_unique_list(video_filepath_list)
 


### PR DESCRIPTION
This PR adds the ability to feed in videos with different frame rates or audio sample rates. Videos that do not have matching frame rates will be resaved with matching frame rates and sample rates before being synchronized. This adds a time/memory cost to the user, but prevents them from needing to perform the same operation manually before synchronizing.

This PR also adds the ability to search for different common media types, rather than just `.mp4`s. The videos are all saved as `.mp4` once synchronized, so they can still be fed directly into freemocap.