### PR TITLE
Fix publish action

### DIFF
--- a/.github/workflows/publish_to_pypi_when_new_tag_is_pushed_to_main.yml
+++ b/.github/workflows/publish_to_pypi_when_new_tag_is_pushed_to_main.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,6 @@ readme = "README.md"
 authors = [{ name = "skelly_synchronize", email = "info@freemocap.org" }]
 license = { file = "LICENSE" }
 
-
-
-
 classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)", #https://www.gnu.org/philosophy/open-source-misses-the-point.en.html
     "Programming Language :: Python",
@@ -43,15 +40,21 @@ dynamic = ["version"]
 [project.optional-dependencies]
 dev = [
     "pytest",
-"black",
-"bumpver", 
-"isort", 
-"pip-tools", 
-"pytest", 
-"flake8",
-"flake8-bandit",
-"flake8-bugbear",
+    "black",
+    "bumpver", 
+    "isort", 
+    "pip-tools", 
+    "pytest", 
+    "flake8",
+    "flake8-bandit",
+    "flake8-bugbear",
 ]
+
+[project.urls]
+Homepage = "https://freemocap.org"
+Documentation = "https://freemocap.github.io/skelly_synchronize/"
+Github = "https://github.com/freemocap/skelly_synchronize"
+
 
 [tool.bumpver] #bump the version by entering `bumpver update` in the terminal
 current_version = "v2024.06.1030"
@@ -64,7 +67,6 @@ push            = true
 [tool.bumpver.file_patterns]
 "pyproject.toml" = ["{version}"]
 "skelly_synchronize/__init__.py" = ["{version}"]
-
 
 [project.scripts]
 skelly_synchronize = "skelly_synchronize.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ Github = "https://github.com/freemocap/skelly_synchronize"
 
 
 [tool.bumpver] #bump the version by entering `bumpver update` in the terminal
-current_version = "v2024.06.1030"
+current_version = "v2023.12.1029"
 version_pattern = "vYYYY.0M.BUILD[-TAG]"
 commit_message  = "Bump version {old_version} -> {new_version}"
 commit          = true

--- a/skelly_synchronize/__init__.py
+++ b/skelly_synchronize/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for basic_template_repo."""
 
 __package_name__ = "skelly_synchronize"
-__version__ = "v2024.06.1030"
+__version__ = "v2023.12.1029"
 
 __author__ = """Philip Queen"""
 __email__ = "info@freemocap.org"


### PR DESCRIPTION
Adds missing metadata causing error with twine here: https://github.com/freemocap/skelly_synchronize/actions/runs/9669769792

Also updates githubs setup actions from v3 to v4