### PR TITLE
allow pyside 6.7.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords = ["basic",
 
 dependencies = [
 "librosa==0.10.1",
-"PySide6==6.6.*",
+"PySide6>=6.6, <6.8",
 "numpy==1.26.2",
 "scipy==1.11.4",
 "opencv-contrib-python==4.8.*",


### PR DESCRIPTION
Allows updating to the newer PySide 6.7, while allowing 6.6 still. This will prevent skellysynchronize from blocking the 6.7 download on freemocap's side.