### PR TITLE
Better ffmpeg finding

### DIFF
--- a/skelly_synchronize/core_processes/video_functions/deffcode_functions.py
+++ b/skelly_synchronize/core_processes/video_functions/deffcode_functions.py
@@ -3,6 +3,10 @@ import logging
 import cv2
 from deffcode import FFdecoder, Sourcer
 
+from skelly_synchronize.core_processes.video_functions.ffmpeg_functions import (
+    check_for_ffmpeg,
+)
+
 tranposition_dictionary = {
     90.0: "transpose=cclock",
     -270.0: "transpose=cclock",
@@ -19,7 +23,14 @@ def trim_single_video_deffcode(
     frame_list: list,
     output_video_pathstring: str,
 ):
-    sourcer = Sourcer(input_video_pathstring).probe_stream()
+    try:
+        ffmpeg_location = check_for_ffmpeg()
+    except FileNotFoundError:
+        ffmpeg_location = ""
+
+    sourcer = Sourcer(
+        source=input_video_pathstring, custom_ffmpeg=ffmpeg_location
+    ).probe_stream()
     metadata_dictionary = sourcer.retrieve_metadata()
 
     if metadata_dictionary["source_video_orientation"] != 0:
@@ -36,6 +47,7 @@ def trim_single_video_deffcode(
     decoder = FFdecoder(
         str(input_video_pathstring),
         frame_format="bgr24",
+        custom_ffmpeg=ffmpeg_location,
         verbose=False,
         **ffparams,
     ).formulate()

--- a/skelly_synchronize/core_processes/video_functions/ffmpeg_functions.py
+++ b/skelly_synchronize/core_processes/video_functions/ffmpeg_functions.py
@@ -12,11 +12,14 @@ ffmpeg_string = "ffmpeg"
 ffprobe_string = "ffprobe"
 
 
-def check_for_ffmpeg():
-    if shutil.which(ffmpeg_string) is None:
+def check_for_ffmpeg() -> str:
+    ffmpeg_pathstring = shutil.which(ffmpeg_string)
+    if ffmpeg_pathstring is None:
         raise FileNotFoundError(
             "ffmpeg not found, please install ffmpeg and add it to your PATH"
         )
+
+    return ffmpeg_pathstring
 
 
 def check_for_ffprobe():


### PR DESCRIPTION
A user on Discord reported that during synch, Deffcode is downloading FFmpeg despite them already having it installed, which has the downstream effect of failing synchronization due to poor network connection. Looking through the Deffcode source, it does appear that on Windows it will download it's own FFmpeg binaries without checking if others exist. 

This PR uses `shutil.which` to check if FFmpeg can be found on the users path, and if so it provides the custom binary path to Deffcode. If FFmpeg cannot be found on the path, it defaults to the above behavior.

## Testing Instructions

In an environment with skelly_synchronize, run `pip uninstall skelly_synchronize` followed by `pip install skelly_synchronize@git+https://github.com/freemocap/skelly_synchronize@philip/better_ffmpeg_finding`

Then attempt to synchronize a video either through freemocap or through skelly synchronize directly.

I have tested that this doesn't interfere with synching on a Mac, but not that it solves the issue on Windows