### PR TITLE
Fix missing -180 value in transposition dictionary

### DIFF
--- a/skelly_synchronize/core_processes/video_functions/deffcode_functions.py
+++ b/skelly_synchronize/core_processes/video_functions/deffcode_functions.py
@@ -9,6 +9,7 @@ tranposition_dictionary = {
     -90.0: "transpose=clock",
     270.0: "transpose=clock",
     180.0: "transpose=cclock,transpose=cclock",
+    -180.0: "transpose=clock,transpose=clock",
 }
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #42 by adding values for the -180 transposition. This should behave the same as the 180 transposition, but apparently some videos will still provide a negative for it.