### PR TITLE
add help behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,4 +69,4 @@ push            = true
 "skelly_synchronize/__init__.py" = ["{version}"]
 
 [project.scripts]
-skelly_synchronize = "skelly_synchronize.__main__:main"
+skelly_synchronize = "skelly_synchronize.__main__:run"

--- a/skelly_synchronize/__main__.py
+++ b/skelly_synchronize/__main__.py
@@ -1,12 +1,22 @@
 # __main__.py
 import sys
 from pathlib import Path
+import argparse
 
 base_package_path = Path(__file__).parent.parent
 print(f"adding base_package_path: {base_package_path} : to sys.path")
 sys.path.insert(0, str(base_package_path))  # add parent directory to sys.path
 
-from gui.skelly_synchronize_gui import main
+def parse_args():
+    parser = argparse.ArgumentParser(description="Skelly Synchronize")
+    return parser.parse_args()
+
+def run():
+    parse_args()
+
+    from gui.skelly_synchronize_gui import main
+    main()
+
 
 if __name__ == "__main__":
-    main()
+    run()


### PR DESCRIPTION
Adding a help argument to `skelly_synchronize`

To test:

1) Create a fresh install of `skelly_synchronize` for this PR
2) Try `skelly_synchronize--help` 
3) Try 'python -m skelly_synchronize --help`

for 2 and 3 you should get a print statement that reads:
```
(skelly_synchronize) C:\Users\aaron\Documents\GitHub\skelly_synchronize>skelly_synchronize --help
13:13:33 ::   Utilities   ::   INFO   :: Running DeFFcode Version: 0.2.6
adding base_package_path: C:\Users\aaron\Documents\GitHub\skelly_synchronize : to sys.path
[2025-01-09 13:13:33.0661] [    INFO] [skelly_synchronize.system.logging_configuration] [configure_logging():39] [PID:28888 TID:37552] Added logging handlers: [<StreamHandler <stdout> (INFO)>, <FileHandler C:\Users\aaron\skelly_synchronize_data\logs_info_and_settings\logs\log_2025-01-09T13_13_33ms659_gmt-5.log (INFO)>]
adding base_package_path: C:\Users\aaron\Documents\GitHub\skelly_synchronize : to sys.path
usage: skelly_synchronize [-h]

Skelly Synchronize

options:
  -h, --help  show this help message and exit
  ```
  
  NOTE: I changed the entry point in the `pyproject.toml` in order to get `skelly_synchronize --help` to work in addition to `python -m skelly_synchronize --help` 