### PR TITLE
Catch RuntimeError in ffmpeg parsing

### DIFF
--- a/skelly_synchronize/__main__.py
+++ b/skelly_synchronize/__main__.py
@@ -7,14 +7,17 @@ base_package_path = Path(__file__).parent.parent
 print(f"adding base_package_path: {base_package_path} : to sys.path")
 sys.path.insert(0, str(base_package_path))  # add parent directory to sys.path
 
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Skelly Synchronize")
     return parser.parse_args()
+
 
 def run():
     parse_args()
 
     from gui.skelly_synchronize_gui import main
+
     main()
 
 

--- a/skelly_synchronize/core_processes/video_functions/ffmpeg_functions.py
+++ b/skelly_synchronize/core_processes/video_functions/ffmpeg_functions.py
@@ -27,9 +27,16 @@ def check_for_ffprobe():
         raise FileNotFoundError(
             "ffprobe not found, please install ffmpeg and add it to your PATH"
         )
-    
+
+
 def parse_ffmpeg_output(output: str, file_pathstring: str) -> float:
-    cleaned_out = str(output).replace("b'", "").replace("'", "").replace("\\n", "").replace("\\", "")
+    cleaned_out = (
+        str(output)
+        .replace("b'", "")
+        .replace("'", "")
+        .replace("\\n", "")
+        .replace("\\", "")
+    )
 
     try:
         output_as_float = float(cleaned_out)
@@ -166,7 +173,9 @@ def extract_audio_sample_rate_ffmpeg(file_pathstring: str):
             f"No audio file found for video {file_pathstring}, check that video has audio"
         )
 
-    audio_sample_rate = parse_ffmpeg_output(str(extract_sample_rate_subprocess.stdout), file_pathstring)
+    audio_sample_rate = parse_ffmpeg_output(
+        str(extract_sample_rate_subprocess.stdout), file_pathstring
+    )
 
     return audio_sample_rate
 
@@ -259,6 +268,7 @@ def attach_audio_to_video_ffmpeg(
         raise RuntimeError(
             f"Error occurred attaching audio to video {input_video_pathstring} with return code {attach_audio_subprocess.returncode}"
         )
+
 
 if __name__ == "__main__":
     video_path = ""

--- a/skelly_synchronize/core_processes/video_functions/ffmpeg_functions.py
+++ b/skelly_synchronize/core_processes/video_functions/ffmpeg_functions.py
@@ -33,7 +33,7 @@ def parse_ffmpeg_output(output: str, file_pathstring: str) -> float:
 
     try:
         output_as_float = float(cleaned_out)
-    except ValueError:
+    except (ValueError, RuntimeError):
         split_str = str(cleaned_out).split("/")
         if len(split_str) == 2:
             output_as_float = float(int(split_str[0])) / float((split_str[1]))

--- a/skelly_synchronize/tests/test_all_files_created.py
+++ b/skelly_synchronize/tests/test_all_files_created.py
@@ -12,7 +12,7 @@ from skelly_synchronize.system.paths_and_file_names import (
 
 @pytest.mark.usefixtures("synchronized_video_folder_path")
 def test_synchronized_video_folder_exists(
-    synchronized_video_folder_path: Union[str, Path]
+    synchronized_video_folder_path: Union[str, Path],
 ):
     assert synchronized_video_folder_path.exists()
 

--- a/skelly_synchronize/tests/utilities/get_number_of_frames_of_videos_in_a_folder.py
+++ b/skelly_synchronize/tests/utilities/get_number_of_frames_of_videos_in_a_folder.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_number_of_frames_of_videos_in_a_folder(
-    folder_path: Union[str, Path]
+    folder_path: Union[str, Path],
 ) -> List[int]:
     """
     Get the number of frames in the first video in a folder


### PR DESCRIPTION
The FFMPEG parsing relies on trying to cast the output to a float, and then handles the input as a fraction if that fails. We were only catching ValueErrors for the the cast-to-float failure, but Aaron is getting it as a RuntimeError on Windows. This PR changes it to catch both kinds of error