### PR TITLE
Handle return character

### DIFF
--- a/skelly_synchronize/core_processes/video_functions/ffmpeg_functions.py
+++ b/skelly_synchronize/core_processes/video_functions/ffmpeg_functions.py
@@ -35,6 +35,8 @@ def parse_ffmpeg_output(output: str, file_pathstring: str) -> float:
         .replace("b'", "")
         .replace("'", "")
         .replace("\\n", "")
+        .replace("\\r", "")
+        .replace("\\t", "")
         .replace("\\", "")
     )
 


### PR DESCRIPTION
The parsing logic for ffmpeg is failing on windows because of an extra `\r` return character not present on mac/linux. This removes that character.