### PR TITLE
Write videos with multiprocessing

### DIFF
--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -1,9 +1,10 @@
 name: Skelly Synchronize Tests
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
-
+  
 
 jobs:
   build:

--- a/skelly_synchronize/core_processes/video_functions/video_utilities.py
+++ b/skelly_synchronize/core_processes/video_functions/video_utilities.py
@@ -108,8 +108,7 @@ def trim_single_video(
         )
 
         if video_handler == "ffmpeg":
-            logger.info(f"Saving video - Cam name: {video_dict['camera name']}")
-            logger.info(f"desired saving duration is: {minimum_duration} seconds")
+            logger.info(f"Saving video - Cam name: {video_dict['camera name']} - target duration: {minimum_duration} seconds")
             trim_single_video_ffmpeg(
                 input_video_pathstring=video_dict["video pathstring"],
                 start_time=start_time,
@@ -122,10 +121,7 @@ def trim_single_video(
                 f"Video Saved - Cam name: {video_dict['camera name']}, Video Duration in Seconds: {minimum_duration}"
             )
         if video_handler == "deffcode":
-            logger.info(f"Saving video - Cam name: {video_dict['camera name']}")
-            logger.info(
-                f"start frame is: {start_frame} desired saving duration is: {minimum_frames} frames"
-            )
+            logger.info(f"Saving video - Cam name: {video_dict['camera name']} - start frame: {start_frame} - target duration: {minimum_frames} frames")
             trim_single_video_deffcode(
                 input_video_pathstring=video_dict["video pathstring"],
                 frame_list=frame_list,

--- a/skelly_synchronize/core_processes/video_functions/video_utilities.py
+++ b/skelly_synchronize/core_processes/video_functions/video_utilities.py
@@ -48,6 +48,7 @@ def create_video_info_dict(
 
     return video_info_dict
 
+
 def trim_videos(
     video_info_dict: Dict[str, dict],
     synchronized_folder_path: Path,
@@ -56,16 +57,16 @@ def trim_videos(
     video_handler: str = "deffcode",
 ) -> None:
     """Take a list of video files and a list of lags, and make all videos start and end at the same time."""
-    
+
     if video_handler not in ["ffmpeg", "deffcode"]:
         raise ValueError("video_handler must be either 'ffmpeg' or 'deffcode'")
-    
+
     minimum_duration = find_minimum_video_duration(
         video_info_dict=video_info_dict, lag_dict=lag_dict
     )
     minimum_frames = int(minimum_duration * fps)
 
-    max_processes = min(len(video_info_dict), multiprocessing.cpu_count()-1)
+    max_processes = min(len(video_info_dict), multiprocessing.cpu_count() - 1)
 
     with multiprocessing.Pool(processes=max_processes) as pool:
         pool.starmap(
@@ -83,6 +84,7 @@ def trim_videos(
                 for video_dict in video_info_dict.values()
             ],
         )
+
 
 def trim_single_video(
     video_dict: dict,
@@ -108,7 +110,9 @@ def trim_single_video(
         )
 
         if video_handler == "ffmpeg":
-            logger.info(f"Saving video - Cam name: {video_dict['camera name']} - target duration: {minimum_duration} seconds")
+            logger.info(
+                f"Saving video - Cam name: {video_dict['camera name']} - target duration: {minimum_duration} seconds"
+            )
             trim_single_video_ffmpeg(
                 input_video_pathstring=video_dict["video pathstring"],
                 start_time=start_time,
@@ -121,7 +125,9 @@ def trim_single_video(
                 f"Video Saved - Cam name: {video_dict['camera name']}, Video Duration in Seconds: {minimum_duration}"
             )
         if video_handler == "deffcode":
-            logger.info(f"Saving video - Cam name: {video_dict['camera name']} - start frame: {start_frame} - target duration: {minimum_frames} frames")
+            logger.info(
+                f"Saving video - Cam name: {video_dict['camera name']} - start frame: {start_frame} - target duration: {minimum_frames} frames"
+            )
             trim_single_video_deffcode(
                 input_video_pathstring=video_dict["video pathstring"],
                 frame_list=frame_list,


### PR DESCRIPTION
This PR uses multiprocessing in the video writing stage of the synchronization process, which is the most time consuming part. There is no change to the external api, so this should just be a "free" speedup of synching.

On my reference 2 camera recording, the time goes from 40s with sequential processing to 30s with parallel processing. On this short recording the gains are more minimal, but should be more pronounced when more cameras are used. 

There is no user input for the max number of processes. In FreeMoCap we've exposed that option because processing consumes increasing ram as data is stored in memory. In this case, frames are immediately read and saved to disk, so ram shouldn't be a problem.